### PR TITLE
Fix missing description error.

### DIFF
--- a/lib/tinyworld.wld
+++ b/lib/tinyworld.wld
@@ -93782,6 +93782,8 @@ you want to get out of here before the Captain finds you.
 ~
 E
 treasre~
+Looks like a lot of money. You grab all that you can because
+you want to get out of here before the Captain finds you.
 ~
 E
 teasure treasures store stores~


### PR DESCRIPTION
Prior to this, at boot time, there was an error:

`No desc in room 21717`

One of the 'extra' descriptions in the room was an empty string.
