### PR TITLE
Add crypt dependency to autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,7 @@ AC_CHECK_HEADERS([criterion/criterion.h],[],[
   AC_MSG_WARN(unit tests will not be runnable without Criterion library)
   AC_MSG_WARN(See https://github.com/Snaipe/Criterion/)
 ])
+AC_SEARCH_LIBS([crypt],[crypt])
 AC_CHECK_LIB(criterion,extmatch,[
   true
 ],[

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,8 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([bzero gethostbyaddr gethostbyname gethostname getpagesize gettimeofday inet_ntoa isascii memset select socket strchr strdup strrchr strstr])
 
+AC_SEARCH_LIBS([crypt],[crypt])
+
 AC_CHECK_HEADERS([criterion/criterion.h],[],[
   AC_MSG_WARN(unit tests will not be runnable without Criterion library)
   AC_MSG_WARN(See https://github.com/Snaipe/Criterion/)


### PR DESCRIPTION
This is needed for Ubuntu (and probably generic Linux) compatibility.
