### PR TITLE
Correct charges on re-entry for NEW_RENT.

### DIFF
--- a/src/reception.c
+++ b/src/reception.c
@@ -302,9 +302,8 @@ void load_char_objs(struct char_data *ch)
       char	buf[MAX_STRING_LENGTH];
       if (ch->in_room == NOWHERE)
 	log_msg("Char reconnecting after autorent");
-#if NEW_RENT
-      timegold = (int) ((100*((float)time(0) - st.last_update)) / 
-			(SECS_PER_REAL_DAY));
+#ifdef NEW_RENT
+      timegold = 0;
 #else
       timegold = (int) ((st.total_cost*((float)time(0) - st.last_update)) / 
 			(SECS_PER_REAL_DAY));


### PR DESCRIPTION
When `NEW_RENT` is defined, the receptionist's offer is 0 gold/day.
However, this is _not_ what is charged on re-entry to the game!
Correcting to at least make it consistent. Will worry about game
balance at a later date.
