### PR TITLE
Make sure game can start with missing or empty player file.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CC
 
-AC_CHECK_HEADERS([arpa/inet.h crypt.h fcntl.h malloc.h netdb.h netinet/in.h stdlib.h signal.h string.h sys/socket.h sys/time.h time.h unistd.h])
+AC_CHECK_HEADERS([arpa/inet.h crypt.h errno.h fcntl.h malloc.h netdb.h netinet/in.h stdlib.h signal.h string.h sys/socket.h sys/stat.h sys/time.h time.h unistd.h])
 
 AC_TYPE_SIZE_T
 AC_CHECK_SIZEOF([void *])

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -3,6 +3,6 @@ sillydatadir = $(localstatedir)/sillymud
 sillydata_DATA = 25102.messages 3093.messages 3094.messages 3095.messages \
   3096.messages 3097.messages 3098.messages 3099.messages Scripts.dat \
   actions bugs credits help help_table ideas info killfile login messages \
-  mortal.board motd news players poses rhyodin skexie.board tinyworld.mob \
+  mortal.board motd news poses rhyodin skexie.board tinyworld.mob \
   tinyworld.shp tinyworld.wld tinyworld.zon typos util wiz.board wizlist \
   wizmotd tinyworld.obj

--- a/src/db.h
+++ b/src/db.h
@@ -141,5 +141,7 @@ struct help_index_element
 
 #define ZONE_LIMBO   512
 
+void ensure_file_exists(const char *path);
+
 #endif
 


### PR DESCRIPTION
This allows us not to install the zero-length `players` file that
came in the original `lib/` directory, and hence lets us run a
`make install` to install a new game executable without over-
writing any existing player characters.

This partially addresses #26.
