### PR TITLE
Improve sprintf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ missing
 # Vagrant
 .vagrant/
 Vagrantfile
+/GPATH
+/GRTAGS
+/GTAGS
+/TAGS

--- a/src/Heap.c
+++ b/src/Heap.c
@@ -87,15 +87,15 @@ void DisplayStringHeap
    for (i=0; i<Heap->uniq; i++) {
      if (type != TO_CHAR) {
         if (Heap->str[i].total > 1) {
-          sprintf(buf, "%s [%d]", Heap->str[i].string, Heap->str[i].total);
+          SPRINTF(buf, "%s [%d]", Heap->str[i].string, Heap->str[i].total);
         } else {
-           sprintf(buf, "%s", Heap->str[i].string);
+           SPRINTF(buf, "%s", Heap->str[i].string);
         }
       } else {
         if (Heap->str[i].total > 1) {
-           sprintf(buf, "%s [%d]\n\r", Heap->str[i].string, Heap->str[i].total);
+           SPRINTF(buf, "%s [%d]\n\r", Heap->str[i].string, Heap->str[i].total);
         } else {
-           sprintf(buf, "%s\n\r", Heap->str[i].string);
+           SPRINTF(buf, "%s\n\r", Heap->str[i].string);
         }
       }
      if (type == TO_CHAR) {

--- a/src/Opinion.c
+++ b/src/Opinion.c
@@ -195,7 +195,7 @@ int Hates( struct char_data *ch, struct char_data *v)
     if (ch->hates.race != -1) {
       if (ch->hates.race == GET_RACE(v)) {
 	char buf[256];
-	sprintf(buf, "You hate %d", GET_RACE(v));
+	SPRINTF(buf, "You hate %d", GET_RACE(v));
 	send_to_char(buf, ch);
 	return(TRUE);
       }

--- a/src/Sound.c
+++ b/src/Sound.c
@@ -113,7 +113,7 @@ void MakeSound(int pulse)
 	  /*
 	   * snore 
 	   */	 
-	  sprintf(buffer, "%s snores loudly.\n\r", ch->player.short_descr);
+	  SPRINTF(buffer, "%s snores loudly.\n\r", ch->player.short_descr);
 	  MakeNoise(ch->in_room, buffer, "You hear a loud snore nearby.\n\r");
 	}
       } else if (GET_POS(ch) == ch->specials.default_pos) {

--- a/src/Trap.c
+++ b/src/Trap.c
@@ -156,7 +156,7 @@ void TrapDamage(struct char_data *v, int damtype, int amnt, struct obj_data *t)
    if (GET_POS(v) == POSITION_DEAD) {
      if (!IS_NPC(v)) {
        if (real_roomp(v->in_room)->name)
-	 sprintf(buf, "%s killed by a trap at %s",
+	 SPRINTF(buf, "%s killed by a trap at %s",
 		 GET_NAME(v),
 		 real_roomp(v->in_room)->name);
        log_msg(buf);
@@ -209,14 +209,14 @@ void TrapDam(struct char_data *v, int damtype, int amnt, struct obj_data *t)
   if ((damtype != TRAP_DAM_TELEPORT)   &&
       (damtype != TRAP_DAM_SLEEP)) {
       if (amnt > 0) {
-    sprintf(buf, "$n is %s by $p!", desc);
+    SPRINTF(buf, "$n is %s by $p!", desc);
     act(buf,TRUE,v,t,0,TO_ROOM);
-    sprintf(buf, "You are %s by $p!", desc);
+    SPRINTF(buf, "You are %s by $p!", desc);
     act(buf,TRUE,v,t,0,TO_CHAR);
       } else {
-    sprintf(buf, "$n is almost %s by $p!", desc);
+    SPRINTF(buf, "$n is almost %s by $p!", desc);
     act(buf,TRUE,v,t,0,TO_ROOM);
-    sprintf(buf, "You are almost %s by $p!", desc);
+    SPRINTF(buf, "You are almost %s by $p!", desc);
     act(buf,TRUE,v,t,0,TO_CHAR);
       }
   }

--- a/src/act.comm.c
+++ b/src/act.comm.c
@@ -36,21 +36,21 @@ void do_say(struct char_data *ch, char *argument, int UNUSED(cmd))
     send_to_char("Yes, but WHAT do you want to say?\n\r", ch);
   else {
     if (IS_NPC(ch)||(IS_SET(ch->specials.act, PLR_ECHO))) {
-      sprintf(buf,"You say '%s'\n\r", argument);
+      SPRINTF(buf,"You say '%s'\n\r", argument);
       send_to_char(buf, ch);
     }
 
     if(GET_RACE(ch) == RACE_OGRE) {
       ogre_garble(argument, buf2, ch);
-      sprintf(buf, "$n says '%s'", buf2);
+      SPRINTF(buf, "$n says '%s'", buf2);
     } else if( GET_RACE(ch) == RACE_DRAAGDIM ) {
       rat_garble(argument, buf2, ch);
-      sprintf(buf, "$n says '%s'", buf2);
+      SPRINTF(buf, "$n says '%s'", buf2);
     } else if(GET_RACE(ch) == RACE_HALFORC) {
       half_orc_garble(argument, buf2, ch);
-      sprintf(buf, "$n says '%s'", buf2);
+      SPRINTF(buf, "$n says '%s'", buf2);
     } else {
-      sprintf(buf,"$n says '%s'", argument);
+      SPRINTF(buf,"$n says '%s'", argument);
     }
     act(buf,FALSE,ch,0,0,TO_ROOM);
   }
@@ -94,21 +94,21 @@ void do_shout(struct char_data *ch, char *argument, int UNUSED(cmd))
     send_to_char("Shout? Yes! Fine! Shout we must, but WHAT??\n\r", ch);
   else	{
     if (IS_NPC(ch) || IS_SET(ch->specials.act, PLR_ECHO)) {
-      sprintf(buf1,"You shout '%s'\n\r", argument);
+      SPRINTF(buf1,"You shout '%s'\n\r", argument);
       send_to_char(buf1, ch);
     }
 
     if(GET_RACE(ch) == RACE_DRAAGDIM) {
       rat_garble(argument, buf2, ch);
-      sprintf(buf1, "$n shouts '%s'", buf2);
+      SPRINTF(buf1, "$n shouts '%s'", buf2);
     } else if(GET_RACE(ch) == RACE_HALFORC) {
       half_orc_garble(argument, buf2, ch);
-      sprintf(buf1, "$n shouts '%s'", buf2);
+      SPRINTF(buf1, "$n shouts '%s'", buf2);
     } else if(GET_RACE(ch) == RACE_OGRE) {
       ogre_garble(argument, buf2, ch);
-      sprintf(buf1, "$n shouts '%s'", buf2);
+      SPRINTF(buf1, "$n shouts '%s'", buf2);
     } else {
-      sprintf(buf1, "$n shouts '%s'", argument);
+      SPRINTF(buf1, "$n shouts '%s'", argument);
     }
 
     act("$n lifts up $s head and shouts loudly", TRUE, ch, 0, 0, TO_ROOM);
@@ -138,10 +138,10 @@ void do_commune(struct char_data *ch, char *argument, int UNUSED(cmd))
     send_to_char("Communing among the gods is fine, but WHAT?\n\r",ch);
   else {
     if (IS_NPC(ch) || IS_SET(ch->specials.act, PLR_ECHO)) {
-      sprintf(buf1,"You think '%s'\n\r", argument);
+      SPRINTF(buf1,"You think '%s'\n\r", argument);
       send_to_char(buf1, ch);
     }
-    sprintf(buf1, "$n thinks '%s'", argument);
+    SPRINTF(buf1, "$n thinks '%s'", argument);
     
     for (i = descriptor_list; i; i = i->next)
       if (i->character != ch && !i->connected && !IS_NPC(i->character) &&
@@ -187,22 +187,22 @@ void do_tell(struct char_data *ch, char *argument, int UNUSED(cmd))
     return;
   
   if (IS_NPC(ch) || IS_SET(ch->specials.act, PLR_ECHO)) { 
-    sprintf(buf,"You tell %s '%s'\n\r",
+    SPRINTF(buf,"You tell %s '%s'\n\r",
 	 (IS_NPC(vict) ? vict->player.short_descr : GET_NAME(vict)), message);
     send_to_char(buf, ch);
   }
 
   if(GET_RACE(ch) == RACE_DRAAGDIM) {
     rat_garble(message, buf2, ch);
-    sprintf(buf,"$n tells you '%s'", buf2);
+    SPRINTF(buf,"$n tells you '%s'", buf2);
   } else if(GET_RACE(ch) == RACE_HALFORC) {
     half_orc_garble(message, buf2, ch);
-    sprintf(buf,"$n tells you '%s'", buf2);
+    SPRINTF(buf,"$n tells you '%s'", buf2);
   } else if(GET_RACE(ch) == RACE_OGRE) {
     ogre_garble(message, buf2, ch);
-    sprintf(buf,"$n tells you '%s'", buf2);
+    SPRINTF(buf,"$n tells you '%s'", buf2);
   } else {
-    sprintf(buf,"$n tells you '%s'", message);
+    SPRINTF(buf,"$n tells you '%s'", message);
   }
   act(buf, TRUE, ch, 0, vict, TO_VICT);
   /* send_to_char(buf, vict); */
@@ -233,10 +233,10 @@ void do_whisper(struct char_data *ch, char *argument, int UNUSED(cmd))
     if (check_soundproof(vict))
       return;
     
-    sprintf(buf,"$n whispers to you, '%s'",message);
+    SPRINTF(buf,"$n whispers to you, '%s'",message);
     act(buf, FALSE, ch, 0, vict, TO_VICT);
     if (IS_NPC(ch) || (IS_SET(ch->specials.act, PLR_ECHO))) {
-      sprintf(buf,"You whisper to %s, '%s'\n\r",
+      SPRINTF(buf,"You whisper to %s, '%s'\n\r",
 	      (IS_NPC(vict) ? vict->player.name : GET_NAME(vict)), message);
       send_to_char(buf, ch);
     }
@@ -267,11 +267,11 @@ void do_ask(struct char_data *ch, char *argument, int UNUSED(cmd))
 	if (check_soundproof(vict))
 	  return;
 
-    sprintf(buf,"$n asks you '%s'",message);
+    SPRINTF(buf,"$n asks you '%s'",message);
     act(buf, FALSE, ch, 0, vict, TO_VICT);
     
     if (IS_NPC(ch) || (IS_SET(ch->specials.act, PLR_ECHO))) {
-      sprintf(buf,"You ask %s, '%s'\n\r",
+      SPRINTF(buf,"You ask %s, '%s'\n\r",
 	    (IS_NPC(vict) ? vict->player.name : GET_NAME(vict)), message);
       send_to_char(buf, ch);
     }
@@ -304,12 +304,12 @@ void do_write(struct char_data *ch, char *argument, int UNUSED(cmd))
       return;
   }
   if (!(paper = get_obj_in_list_vis(ch, papername, ch->carrying)))	{
-	  sprintf(buf, "You have no %s.\n\r", papername);
+	  SPRINTF(buf, "You have no %s.\n\r", papername);
 	  send_to_char(buf, ch);
 	  return;
    }
    if (!(pen = get_obj_in_list_vis(ch, penname, ch->carrying)))	{
-	  sprintf(buf, "You have no %s.\n\r", papername);
+	  SPRINTF(buf, "You have no %s.\n\r", papername);
 	  send_to_char(buf, ch);
 	  return;
     }
@@ -449,7 +449,7 @@ void do_sign(struct char_data *ch, char *argument, int UNUSED(cmd))
       buf2 is now the "corrected" string.
       */
 
-    sprintf(buf,"$n signs '%s'", buf2);
+    SPRINTF(buf,"$n signs '%s'", buf2);
 
     for (t = rp->people;t;t=t->next_in_room) {
       if (t != ch) {
@@ -463,7 +463,7 @@ void do_sign(struct char_data *ch, char *argument, int UNUSED(cmd))
     }
 
     if (IS_NPC(ch)||(IS_SET(ch->specials.act, PLR_ECHO))) {
-      sprintf(buf,"You sign '%s'\n\r", argument + i);
+      SPRINTF(buf,"You sign '%s'\n\r", argument + i);
       send_to_char(buf, ch);
     }
   }

--- a/src/act.info.c
+++ b/src/act.info.c
@@ -284,7 +284,7 @@ void show_mult_obj_to_char(struct obj_data *object, struct char_data *ch, int mo
   }
   
   if (num>1) {
-    sprintf(tmp,"[%d]", num);
+    SPRINTF(tmp,"[%d]", num);
     strcat(buffer, tmp);
   }
   strcat(buffer, "\n\r");
@@ -339,7 +339,7 @@ void list_obj_in_room(struct obj_data *list, struct char_data *ch)
 	num = number(1,101);
 	if (ch->skills && (num < (ch->skills[SKILL_LOCATE_TRAP].learned/2))) {
 	  if (cond_tot[k] > 1) {
-	    sprintf(buf,"[%2d] ",Inventory_Num++);
+	    SPRINTF(buf,"[%2d] ",Inventory_Num++);
 	    send_to_char(buf,ch);
 	    show_mult_obj_to_char(cond_ptr[k],ch,0,cond_tot[k]);
 	  } else {
@@ -348,7 +348,7 @@ void list_obj_in_room(struct obj_data *list, struct char_data *ch)
 	}
       } else {
 	if (cond_tot[k] > 1) {
-	  sprintf(buf,"[%2d] ",Inventory_Num++);
+	  SPRINTF(buf,"[%2d] ",Inventory_Num++);
 	  send_to_char(buf,ch);
 	  show_mult_obj_to_char(cond_ptr[k],ch,0,cond_tot[k]);
 	} else {
@@ -395,7 +395,7 @@ void list_obj_in_heap(struct obj_data *list, struct char_data *ch)
   
   if (cond_top) {
     for (k=0; k<cond_top; k++) {
-      sprintf(buf,"[%2d] ",Num_Inventory++);
+      SPRINTF(buf,"[%2d] ",Num_Inventory++);
       send_to_char(buf,ch);
       if (cond_tot[k] > 1) {
 	Num_Inventory += cond_tot[k] - 1;
@@ -417,7 +417,7 @@ void list_obj_to_char(struct obj_data *list,struct char_data *ch, int mode,
   found = FALSE;
   for ( i = list ; i ; i = i->next_content ) { 
     if (CAN_SEE_OBJ(ch,i)) {
-      sprintf(buf,"[%2d] ",Num_In_Bag++);
+      SPRINTF(buf,"[%2d] ",Num_In_Bag++);
       send_to_char(buf,ch);
       show_obj_to_char(i, ch, mode);
       found = TRUE;
@@ -567,17 +567,17 @@ void show_char_to_char(struct char_data *i, struct char_data *ch, int mode)
 */
 
     if (IS_PC(i)) {
-	sprintf(buffer, "$n is %s", RaceName[GET_RACE(i)]);
+	SPRINTF(buffer, "$n is %s", RaceName[GET_RACE(i)]);
 	act(buffer, FALSE, i, 0, ch, TO_VICT);	
     }
 
     if (MOUNTED(i)) {
-      sprintf(buffer,"$n is mounted on %s", MOUNTED(i)->player.short_descr);
+      SPRINTF(buffer,"$n is mounted on %s", MOUNTED(i)->player.short_descr);
       act(buffer, FALSE, i, 0, ch, TO_VICT);
     }
     
     if (RIDDEN(i)) {
-      sprintf(buffer,"$n is ridden by %s", IS_NPC(RIDDEN(i))?RIDDEN(i)->player.short_descr:GET_NAME(RIDDEN(i)));
+      SPRINTF(buffer,"$n is ridden by %s", IS_NPC(RIDDEN(i))?RIDDEN(i)->player.short_descr:GET_NAME(RIDDEN(i)));
       act(buffer, FALSE, i, 0, ch, TO_VICT);
     }
 
@@ -779,7 +779,7 @@ void show_mult_char_to_char(struct char_data *i, struct char_data *ch, int mode,
       }
       
       if (num > 1) {
-	sprintf(tmp," [%d]", num);
+	SPRINTF(tmp," [%d]", num);
 	strcat(buffer, tmp);
       }
       strcat(buffer,"\n\r");
@@ -806,7 +806,7 @@ void show_mult_char_to_char(struct char_data *i, struct char_data *ch, int mode,
 	       (buffer[strlen(buffer)-1]==' ')) {
 	  buffer[strlen(buffer)-1] = '\0';
 	}
-	sprintf(tmp," [%d]\n\r", num);
+	SPRINTF(tmp," [%d]\n\r", num);
 	strcat(buffer, tmp);
       }
       
@@ -1035,14 +1035,14 @@ void do_look(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	     (exitp->keyword)) {
 	   if ((strcmp(fname(exitp->keyword), "secret")) &&
 	       (!IS_SET(exitp->exit_info, EX_SECRET))) {
-	     sprintf(buffer, "The %s is closed.\n\r", 
+	     SPRINTF(buffer, "The %s is closed.\n\r", 
 		     fname(exitp->keyword));
 	     send_to_char(buffer, ch);
 	   } 
 	 } else {
 	   if (IS_SET(exitp->exit_info, EX_ISDOOR) &&
 	       exitp->keyword) {
-	     sprintf(buffer, "The %s is open.\n\r",
+	     SPRINTF(buffer, "The %s is open.\n\r",
 		     fname(exitp->keyword));
 	     send_to_char(buffer, ch);
 	   }
@@ -1054,17 +1054,17 @@ void do_look(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 				       (!IS_SET(exitp->exit_info, EX_CLOSED)))) {
 	 if (IS_AFFECTED(ch, AFF_SCRYING) || IS_IMMORTAL(ch)) {
 	   struct room_data	*rp;
-	   sprintf(buffer,"You look %swards.\n\r", dirs[keyword_no]);
+	   SPRINTF(buffer,"You look %swards.\n\r", dirs[keyword_no]);
 	   send_to_char(buffer, ch);
 	   
-	   sprintf(buffer,"$n looks %swards.", dirs[keyword_no]);
+	   SPRINTF(buffer,"$n looks %swards.", dirs[keyword_no]);
 	   act(buffer, FALSE, ch, 0, 0, TO_ROOM);
 	   
 	   rp = real_roomp(exitp->to_room);
 	   if (!rp) {
 	     send_to_char("You see swirling chaos.\n\r", ch);
 	   } else if(exitp) {
-	     sprintf(buffer, "%d look", exitp->to_room);
+	     SPRINTF(buffer, "%d look", exitp->to_room);
 	     do_at(ch, buffer, 0);
 	   } else {
 	     send_to_char("You see nothing special.\n\r", ch);
@@ -1087,7 +1087,7 @@ void do_look(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	      act("It is empty.", FALSE, ch, 0, 0, TO_CHAR);
 	    } else {
 	      temp=((tmp_object->obj_flags.value[1]*3)/tmp_object->obj_flags.value[0]);
-	      sprintf(buffer,"It's %sfull of a %s liquid.\n\r",
+	      SPRINTF(buffer,"It's %sfull of a %s liquid.\n\r",
 		      fullness[temp],color_liquid[tmp_object->obj_flags.value[2]]);
 	      send_to_char(buffer, ch);
 	    }
@@ -1339,7 +1339,7 @@ void do_read(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   char buf[100];
   
   /* This is just for now - To be changed later.! */
-  sprintf(buf,"at %s",argument);
+  SPRINTF(buf,"at %s",argument);
   do_look(ch,buf,15);
 }
 
@@ -1348,7 +1348,7 @@ void do_examine(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   struct char_data *tmp_char;
   struct obj_data *tmp_object;
   
-  sprintf(buf,"at %s",argument);
+  SPRINTF(buf,"at %s",argument);
   do_look(ch,buf,15);
   
   one_argument(argument, name);
@@ -1365,7 +1365,7 @@ void do_examine(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     if ((GET_ITEM_TYPE(tmp_object)==ITEM_DRINKCON) ||
 	(GET_ITEM_TYPE(tmp_object)==ITEM_CONTAINER)) {
       send_to_char("When you look inside, you see:\n\r", ch);
-      sprintf(buf,"in %s",argument);
+      SPRINTF(buf,"in %s",argument);
       do_look(ch,buf,15);
     }
   }
@@ -1387,7 +1387,7 @@ void show_exits(struct char_data *ch)
       } else if (exitdata->to_room != NOWHERE &&
 		 (!IS_SET(exitdata->exit_info, EX_CLOSED) ||
 		  IS_IMMORTAL(ch))) {
-	  sprintf(buf + strlen(buf), "%s ", exits[door]);
+        SAPPENDF(buf, "%s ", exits[door]);
       }
     }
   }
@@ -1420,28 +1420,27 @@ void do_exits(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
       if (!real_roomp(exitdata->to_room)) {
 	/* don't print unless immortal */
 	if (IS_IMMORTAL(ch)) {
-	  sprintf(buf + strlen(buf), "%s - swirling chaos of #%d\n\r",
+	  SAPPENDF(buf, "%s - swirling chaos of #%d\n\r",
 	    	  exits[door], exitdata->to_room);
         }
       }
       else if (exitdata->to_room != NOWHERE) {
         if (IS_IMMORTAL(ch)){
-          sprintf(buf + strlen(buf), "%s - %s", exits[door],
+          SAPPENDF(buf, "%s - %s", exits[door],
                   real_roomp(exitdata->to_room)->name);
           if(IS_SET(exitdata->exit_info, EX_CLOSED))
             strcat(buf, " (closed)");
           if(IS_DARK(exitdata->to_room))
             strcat(buf, " (dark)");
-          sprintf(buf + strlen(buf), " #%d\n\r", exitdata->to_room);
+          SAPPENDF(buf, " #%d\n\r", exitdata->to_room);
         }
         else if (!IS_SET(exitdata->exit_info, EX_CLOSED)) {
           if (IS_DARK(exitdata->to_room) && !IS_AFFECTED(ch, AFF_TRUE_SIGHT)) {
 	    if(IS_AFFECTED(ch, AFF_INFRAVISION) || IS_LIGHT(ch->in_room))
-	      sprintf(buf + strlen(buf), "%s - Too dark to tell\n\r", 
-		      exits[door]);
+	      SAPPENDF(buf, "%s - Too dark to tell\n\r", exits[door]);
 	  } else
-            sprintf(buf + strlen(buf), "%s - %s\n\r", exits[door],
-		    real_roomp(exitdata->to_room)->name);
+            SAPPENDF(buf, "%s - %s\n\r", exits[door],
+                    real_roomp(exitdata->to_room)->name);
         }
       }
     }
@@ -1465,7 +1464,7 @@ void do_score(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
   struct time_info_data real_time_passed(time_t t2, time_t t1);
 
   age2(ch, &my_age);
-  sprintf(buf, "You are %d years old.", my_age.year);
+  SPRINTF(buf, "You are %d years old.", my_age.year);
   
   
   if ((my_age.month == 0) && (my_age.year == 0))
@@ -1474,7 +1473,7 @@ void do_score(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
     strcat(buf,"\n\r");
   send_to_char(buf, ch);
 
-  sprintf(buf, "You belong to the %s race\n\r", RaceName[GET_RACE(ch)]);
+  SPRINTF(buf, "You belong to the %s race\n\r", RaceName[GET_RACE(ch)]);
   send_to_char(buf, ch);
   
   if (!IS_IMMORTAL(ch) && (!IS_NPC(ch))) {
@@ -1486,7 +1485,7 @@ void do_score(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
       send_to_char("You are thirsty...\n\r", ch);
   }
   
-  sprintf(buf, 
+  SPRINTF(buf, 
 	  "You have %d(%d) hit, %d(%d) mana and %d(%d) movement points.\n\r",
 	  GET_HIT(ch),GET_MAX_HIT(ch),
 	  GET_MANA(ch),GET_MAX_MANA(ch),
@@ -1494,45 +1493,45 @@ void do_score(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
   send_to_char(buf,ch);
 
   if(HasClass(ch, CLASS_DRUID)) 
-    sprintf(buf, "Your alignment is: %s (%d).\n\r", 
+    SPRINTF(buf, "Your alignment is: %s (%d).\n\r", 
 	    AlignDesc(GET_ALIGNMENT(ch)), GET_ALIGNMENT(ch));
   else 
-    sprintf(buf, "Your alignment is: %s.\n\r", 
+    SPRINTF(buf, "Your alignment is: %s.\n\r", 
 	    AlignDesc(GET_ALIGNMENT(ch)));
 
   send_to_char(buf,ch);
   
-  sprintf(buf, "Your ego is of %s proportions.\n\r", EgoDesc(GET_EGO(ch)));
+  SPRINTF(buf, "Your ego is of %s proportions.\n\r", EgoDesc(GET_EGO(ch)));
   send_to_char(buf,ch);
 
-  sprintf(buf,"You have scored %d exp, and have %d gold coins.\n\r",
+  SPRINTF(buf,"You have scored %d exp, and have %d gold coins.\n\r",
 	  GET_EXP(ch),GET_GOLD(ch));
   send_to_char(buf,ch);
 
   buf[0] = '\0';
-  sprintf(buf, "Your levels:");
+  SPRINTF(buf, "Your levels:");
   if (HasClass(ch, CLASS_MAGIC_USER)) {
-    sprintf(buf2, " M:%d", GET_LEVEL(ch, MAGE_LEVEL_IND));
+    SPRINTF(buf2, " M:%d", GET_LEVEL(ch, MAGE_LEVEL_IND));
     strcat(buf, buf2);
   }
   if (HasClass(ch, CLASS_CLERIC)) {
-    sprintf(buf2, " C:%d", GET_LEVEL(ch, CLERIC_LEVEL_IND));
+    SPRINTF(buf2, " C:%d", GET_LEVEL(ch, CLERIC_LEVEL_IND));
     strcat(buf, buf2);
   }
   if (HasClass(ch, CLASS_WARRIOR)) {
-    sprintf(buf2, " W:%d", GET_LEVEL(ch, WARRIOR_LEVEL_IND));
+    SPRINTF(buf2, " W:%d", GET_LEVEL(ch, WARRIOR_LEVEL_IND));
     strcat(buf, buf2);
   }
   if (HasClass(ch, CLASS_THIEF)) {
-    sprintf(buf2, " T:%d", GET_LEVEL(ch, THIEF_LEVEL_IND));
+    SPRINTF(buf2, " T:%d", GET_LEVEL(ch, THIEF_LEVEL_IND));
     strcat(buf, buf2);
   }
   if (HasClass(ch, CLASS_DRUID)) {
-    sprintf(buf2, " D:%d", GET_LEVEL(ch, DRUID_LEVEL_IND));
+    SPRINTF(buf2, " D:%d", GET_LEVEL(ch, DRUID_LEVEL_IND));
     strcat(buf, buf2);
   }
   if (HasClass(ch, CLASS_MONK)) {
-    sprintf(buf2, " K:%d", GET_LEVEL(ch, MONK_LEVEL_IND));
+    SPRINTF(buf2, " K:%d", GET_LEVEL(ch, MONK_LEVEL_IND));
     strcat(buf, buf2);
   }
 
@@ -1540,13 +1539,13 @@ void do_score(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
   send_to_char(buf,ch);
 
   if (GET_TITLE(ch)) {
-    sprintf(buf,"This ranks you as %s %s.\n\r", GET_NAME(ch), GET_TITLE(ch));
+    SPRINTF(buf,"This ranks you as %s %s.\n\r", GET_NAME(ch), GET_TITLE(ch));
     send_to_char(buf,ch);
   }
   
   playing_time = real_time_passed((time(0)-ch->player.time.logon) +
 				  ch->player.time.played, 0);
-  sprintf(buf,"You have been playing for %d days and %d hours.\n\r",
+  SPRINTF(buf,"You have been playing for %d days and %d hours.\n\r",
 	  playing_time.day,
 	  playing_time.hours);		
   send_to_char(buf, ch);		
@@ -1598,7 +1597,7 @@ void do_time(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
   extern const char *weekdays[];
   extern const char *month_name[];
   
-  sprintf(buf, "It is %d o'clock %s, on ",
+  SPRINTF(buf, "It is %d o'clock %s, on ",
 	  ((time_info.hours % 12 == 0) ? 12 : ((time_info.hours) % 12)),
 	  ((time_info.hours >= 12) ? "pm" : "am") );
   
@@ -1627,7 +1626,7 @@ void do_time(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
   else
     suf = "th";
   
-  sprintf(buf, "The %d%s Day of the %s, Year %d.\n\r",
+  SPRINTF(buf, "The %d%s Day of the %s, Year %d.\n\r",
 	  day,
 	  suf,
 	  month_name[(int)time_info.month],
@@ -1648,7 +1647,7 @@ void do_weather(struct char_data *ch, char * UNUSED(argument),
     "lit by flashes of lightning"};
   
   if (OUTSIDE(ch)) {
-    sprintf(buf, 
+    SPRINTF(buf, 
 	    "The sky is %s and %s.\n\r",
 	    sky_look[weather_info.sky],
 	    (weather_info.change >=0 ? "you feel a warm wind from south" :
@@ -1732,15 +1731,15 @@ void do_wizhelp(struct char_data *ch, char * UNUSED(arg), int UNUSED(cmd)) {
  if(IS_NPC(ch))
     return;
  
- sprintf(buf, "Wizard Commands Available To You:\n\r\n\r");
+ SPRINTF(buf, "Wizard Commands Available To You:\n\r\n\r");
  
  for(i = 0; i < 26; i++) {
     n = radix_head[i].next;
     while(n) {
         if(n->min_level <= GetMaxLevel(ch) && n->min_level >= LOW_IMMORTAL) {
-           sprintf((buf + strlen(buf)), "%-10s", n->name);
+           SAPPENDF(buf, "%-10s", n->name);
            if(!(j % 7))
-              sprintf((buf + strlen(buf)), "\n\r");
+             SAPPENDF(buf, "\n\r");
            j++;
 	 }
         n = n->next;
@@ -1789,19 +1788,19 @@ void do_who(struct char_data *ch, char *argument, int cmd)
 			)->in_room)->zone == real_roomp(ch->in_room)->zone || 
 	   cmd!=234 ) && (!gods || IS_IMMORTAL(d->character))) {
 	count++;
-	sprintf(buf, "%s %s", 
+	SPRINTF(buf, "%s %s", 
 		GET_NAME(person),
 		(person->player.title?person->player.title:"(Null)"));
 	
 	if (cmd==234) { /* it's a whozone command */
 	  if ((!IS_AFFECTED(person, AFF_HIDE)) || (IS_IMMORTAL(ch))) {
-	    sprintf(buf,"%-25s - %s ", GET_NAME(person),
+	    SPRINTF(buf,"%-25s - %s ", GET_NAME(person),
 		    real_roomp(person->in_room)->name);
 	    if (GetMaxLevel(ch) >= LOW_IMMORTAL)
-	      sprintf(buf+strlen(buf),"[%d]", person->in_room);
+	      SAPPENDF(buf,"[%d]", person->in_room);
 	  }
 	} else {
-	  sprintf(buf, "%s %s", 
+	  SPRINTF(buf, "%s %s", 
 		  GET_NAME(person),
 		  (person->player.title?person->player.title:"(Null)"));
 	}
@@ -1810,7 +1809,7 @@ void do_who(struct char_data *ch, char *argument, int cmd)
 	send_to_char(buf, ch);
       }
     }
-    sprintf(buf, "\n\rTotal visible players: %d\n\r", count);
+    SPRINTF(buf, "\n\rTotal visible players: %d\n\r", count);
     send_to_char(buf, ch);
     
   } else {
@@ -1828,7 +1827,7 @@ void do_who(struct char_data *ch, char *argument, int cmd)
 	  if (person->desc == NULL) {
 	    lcount++;
 	  } else {
-	    sprintf(buf, "%s %s\n\r", 
+	    SPRINTF(buf, "%s %s\n\r", 
 		    GET_NAME(person),
 		    (person->player.title?person->player.title:"(Null)"));
 	    send_to_char(buf,ch);
@@ -1875,16 +1874,16 @@ void do_who(struct char_data *ch, char *argument, int cmd)
 	    if (!skip) {
 	      if (person->desc == NULL) {
 		if (index(arg,'d') != NULL) {
-		  sprintf(buf, "[%-12s] ", GET_NAME(person));
+		  SPRINTF(buf, "[%-12s] ", GET_NAME(person));
 		  listed++;
 		}
 	      } else {
 		if (IS_NPC(person) && 
 		    IS_SET(person->specials.act, ACT_POLYSELF)) {
-		  sprintf(buf, "(%-14s) ", GET_NAME(person));
+		  SPRINTF(buf, "(%-14s) ", GET_NAME(person));
 		  listed++;
 		} else {
-		  sprintf(buf, "%-14s ", GET_NAME(person));
+		  SPRINTF(buf, "%-14s ", GET_NAME(person));
 		  listed++;
 		}
 	      }
@@ -1892,12 +1891,12 @@ void do_who(struct char_data *ch, char *argument, int cmd)
 		for (l = 1; (size_t)l <= strlen(arg) ; l++) {
 		  switch (arg[l]) {
 		  case 'i': {
-		    sprintf(tempbuf,"Idle:[%-3d] ",person->specials.timer);
+		    SPRINTF(tempbuf,"Idle:[%-3d] ",person->specials.timer);
 		    strcat(buf,tempbuf);
 		    break;
 		  }
 		  case 'l': {
-		    sprintf(tempbuf,"Level:[%-2d/%-2d/%-2d/%-2d/%-2d/%-2d] ",
+		    SPRINTF(tempbuf,"Level:[%-2d/%-2d/%-2d/%-2d/%-2d/%-2d] ",
 			    person->player.level[0],person->player.level[1],
 			    person->player.level[2],person->player.level[3],
 			    person->player.level[4],person->player.level[5]);
@@ -1905,17 +1904,17 @@ void do_who(struct char_data *ch, char *argument, int cmd)
 		    break;
 		  }
 		  case 'h': {
-		    sprintf(tempbuf,"Hit:[%-3d] Mana:[%-3d] Move:[%-3d] ",GET_HIT(person),GET_MANA(person),GET_MOVE(person));
+		    SPRINTF(tempbuf,"Hit:[%-3d] Mana:[%-3d] Move:[%-3d] ",GET_HIT(person),GET_MANA(person),GET_MOVE(person));
 		    strcat(buf,tempbuf);
 		    break;
 		  }		 
 		  case 's': {
-		    sprintf(tempbuf,"[S:%-2d I:%-2d W:%-2d C:%-2d D:%-2d] ",GET_STR(person),GET_INT(person),GET_WIS(person),GET_CON(person),GET_DEX(person));
+		    SPRINTF(tempbuf,"[S:%-2d I:%-2d W:%-2d C:%-2d D:%-2d] ",GET_STR(person),GET_INT(person),GET_WIS(person),GET_CON(person),GET_DEX(person));
 		    strcat(buf,tempbuf);
 		    break;
 		  }		 
 		  case 't': {
-		    sprintf(tempbuf," %-16s ",(person->player.title?person->player.title:"(null)"));
+		    SPRINTF(tempbuf," %-16s ",(person->player.title?person->player.title:"(null)"));
 		    strcat(buf,tempbuf);
 		    break;
 		  }		 
@@ -1941,7 +1940,7 @@ void do_who(struct char_data *ch, char *argument, int cmd)
 	      if (person->desc == NULL) {
 		lcount++;
 	      } else {
-		sprintf(buf, "%s %s\n\r", GET_NAME(person), (person->player.title?person->player.title:"(null)"));
+		SPRINTF(buf, "%s %s\n\r", GET_NAME(person), (person->player.title?person->player.title:"(null)"));
 		send_to_char(buf,ch);
 	      }
 	    }
@@ -1950,11 +1949,11 @@ void do_who(struct char_data *ch, char *argument, int cmd)
       }
     }
     if (listed == 0) {
-      sprintf(buf, "\n\rTotal players / Link dead [%d/%d] (%2.0f%%)\n\r",
+      SPRINTF(buf, "\n\rTotal players / Link dead [%d/%d] (%2.0f%%)\n\r",
 	      count,lcount,((float)lcount / (int)count) * 100);
       send_to_char(buf, ch);
     } else {
-      sprintf(buf, "\n\rTotal players / Link dead [%d/%d] (%2.0f%%) Number Listed: %d\n\r",
+      SPRINTF(buf, "\n\rTotal players / Link dead [%d/%d] (%2.0f%%) Number Listed: %d\n\r",
 	      count,lcount,((float)lcount / (int)count) * 100,listed);
       send_to_char(buf, ch);
     }
@@ -1972,17 +1971,17 @@ void do_users(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
   for (d = descriptor_list; d; d = d->next){
       if (d->character && d->character->player.name){
 	if(d->original)
-	  sprintf(line, "%-16s: ", d->original->player.name);
+	  SPRINTF(line, "%-16s: ", d->original->player.name);
 	else
-	  sprintf(line, "%-16s: ", d->character->player.name);
+	  SPRINTF(line, "%-16s: ", d->character->player.name);
       } else
-	sprintf(line, "UNDEFINED       : ");
+	SPRINTF(line, "UNDEFINED       : ");
       if (*d->host != '\0') {
-	sprintf(buf2, "%-22s [%s]\n\r", connected_types[d->connected],d->host);
+	SPRINTF(buf2, "%-22s [%s]\n\r", connected_types[d->connected],d->host);
       } else if(d) {
-	sprintf(buf2, "%-22s [%s]\n\r", connected_types[d->connected],"????");
+	SPRINTF(buf2, "%-22s [%s]\n\r", connected_types[d->connected],"????");
       } else {
-	sprintf(buf2, "%-22s [%s]\n\r", "ACK, FIDO!", "booga");
+	SPRINTF(buf2, "%-22s [%s]\n\r", "ACK, FIDO!", "booga");
       }
       strcat(line, buf2);
       strcat(buf, line);
@@ -2010,7 +2009,7 @@ void do_equipment(struct char_data *ch, char * UNUSED(argument),
   for (Worn_Index = j=0; j< MAX_WEAR; j++) {
     if (ch->equipment[j]) {
       Worn_Index++;
-      sprintf(String,"[%d] %s",Worn_Index,where[j]);
+      SPRINTF(String,"[%d] %s",Worn_Index,where[j]);
       send_to_char(String,ch);
       if (CAN_SEE_OBJ(ch,ch->equipment[j])) {
 	show_obj_to_char(ch->equipment[j],ch,1);
@@ -2069,7 +2068,7 @@ char *numbered_person(struct char_data *ch, struct char_data *person)
 {
   static char buf[MAX_STRING_LENGTH];
   if (IS_NPC(person) && IS_IMMORTAL(ch)) {
-    sprintf(buf, "%d.%s", which_number_mobile(person),
+    SPRINTF(buf, "%d.%s", which_number_mobile(person),
 	    fname(person->player.name));
   } else {
     strcpy(buf, PERS(person, ch));
@@ -2081,11 +2080,11 @@ void do_where_person(struct char_data *ch, struct char_data *person, struct stri
 {
   char buf[MAX_STRING_LENGTH];
   
-  sprintf(buf, "%-30s- %s ", PERS(person, ch),
+  SPRINTF(buf, "%-30s- %s ", PERS(person, ch),
 	  (person->in_room > -1 ? real_roomp(person->in_room)->name : "Nowhere"));
   
   if (GetMaxLevel(ch) >= LOW_IMMORTAL)
-    sprintf(buf+strlen(buf),"[%d]", person->in_room);
+    SAPPENDF(buf,"[%d]", person->in_room);
   
   strcpy(buf+strlen(buf), "\n\r");
   
@@ -2097,24 +2096,24 @@ void do_where_object(struct char_data *ch, struct obj_data *obj,
 {
   char buf[MAX_STRING_LENGTH];
   if (obj->in_room != NOWHERE) { /* object in a room */
-    sprintf(buf, "%-30s- %s [%d]\n\r",
+    SPRINTF(buf, "%-30s- %s [%d]\n\r",
 	    obj->short_description,
 	    real_roomp(obj->in_room)->name,
 	    obj->in_room);
   } else if (obj->carried_by != NULL) { /* object carried by monster */
-    sprintf(buf, "%-30s- carried by %s\n\r",
+    SPRINTF(buf, "%-30s- carried by %s\n\r",
 	    obj->short_description,
 	    numbered_person(ch, obj->carried_by));
   } else if (obj->equipped_by != NULL) { /* object equipped by monster */
-    sprintf(buf, "%-30s- equipped by %s\n\r",
+    SPRINTF(buf, "%-30s- equipped by %s\n\r",
 	    obj->short_description,
 	    numbered_person(ch, obj->equipped_by));
   } else if (obj->in_obj) { /* object in object */
-    sprintf(buf, "%-30s- in %s\n\r",
+    SPRINTF(buf, "%-30s- in %s\n\r",
 	    obj->short_description,
 	    obj->in_obj->short_description);
   } else {
-    sprintf(buf, "%-30s- god doesn't even know where...\n\r",
+    SPRINTF(buf, "%-30s- god doesn't even know where...\n\r",
 	    obj->short_description);
   }
   if (*buf)
@@ -2154,13 +2153,13 @@ void do_where(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       for (d = descriptor_list; d; d = d->next) {
 	if (d->character && (d->connected == CON_PLYNG) && (d->character->in_room != NOWHERE)) {
 	  if (d->original)   /* If switched */
-	    sprintf(buf, "%-20s - %s [%d] In body of %s\n\r",
+	    SPRINTF(buf, "%-20s - %s [%d] In body of %s\n\r",
 		    d->original->player.name,
 		    real_roomp(d->character->in_room)->name,
 		    d->character->in_room,
 		    fname(d->character->player.name));
 	  else
-	    sprintf(buf, "%-20s - %s [%d]\n\r",
+	    SPRINTF(buf, "%-20s - %s [%d]\n\r",
 		    d->character->player.name,
 		    real_roomp(d->character->in_room)->name,
 		    d->character->in_room);
@@ -2192,7 +2191,7 @@ void do_where(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 					     real_roomp(ch->in_room)->zone))) {
 	if (number==0 || (--count) == 0) {
 	  if (number==0) {
-	    sprintf(buf, "[%2d] ", ++count); /* I love short circuiting :) */
+	    SPRINTF(buf, "[%2d] ", ++count); /* I love short circuiting :) */
 	    append_to_string_block(&sb, buf);
 	  }
 	  do_where_person(ch, i, &sb);
@@ -2212,7 +2211,7 @@ void do_where(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       if (isname(name, k->name) && CAN_SEE_OBJ(ch, k)) {
 	if (number==0 || (--count)==0) {
 	  if (number==0) {
-	    sprintf(buf, "[%2d] ", ++count);
+	    SPRINTF(buf, "[%2d] ", ++count);
 	    append_to_string_block(&sb, buf);
 	  }
 	  do_where_object(ch, k, number!=0, &sb);
@@ -2259,11 +2258,11 @@ void do_levels(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       return;
     }
     
-    sprintf(buf,"You have scored %d experience points.\n\r",GET_EXP(ch));
+    SPRINTF(buf,"You have scored %d experience points.\n\r",GET_EXP(ch));
     send_to_char(buf,ch);
     if (HasClass(ch, CLASS_MAGIC_USER)) {
       exp = (titles[MAGE_LEVEL_IND][GET_LEVEL(ch,MAGE_LEVEL_IND) + 1].exp);
-      sprintf(buf,
+      SPRINTF(buf,
               "You need %d experience points to become a level %d mage.\n\r",
               exp - GET_EXP(ch),
 	      GET_LEVEL(ch,MAGE_LEVEL_IND) +1);
@@ -2272,7 +2271,7 @@ void do_levels(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     
     if (HasClass(ch, CLASS_CLERIC)) {
       exp = (titles[CLERIC_LEVEL_IND][GET_LEVEL(ch,CLERIC_LEVEL_IND)+1].exp);
-      sprintf(buf,
+      SPRINTF(buf,
               "You need %d experience points to become a level %d cleric.\n\r",
 	      exp - GET_EXP(ch),
 	      GET_LEVEL(ch,CLERIC_LEVEL_IND) +1);
@@ -2281,7 +2280,7 @@ void do_levels(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     
     if (HasClass(ch, CLASS_WARRIOR)) {
       exp = titles[WARRIOR_LEVEL_IND][GET_LEVEL(ch,WARRIOR_LEVEL_IND)+1].exp;
-      sprintf(buf,
+      SPRINTF(buf,
 	      "You need %d experience points to become a level %d warrior.\n\r",
 	      exp - GET_EXP(ch),
 	      GET_LEVEL(ch,WARRIOR_LEVEL_IND) +1);
@@ -2289,7 +2288,7 @@ void do_levels(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
     if (HasClass(ch, CLASS_THIEF)) {
       exp = titles[THIEF_LEVEL_IND][GET_LEVEL(ch,THIEF_LEVEL_IND) + 1].exp;
-      sprintf(buf,
+      SPRINTF(buf,
               "You need %d experience points to become a level %d thief.\n\r",
               exp - GET_EXP(ch),
               GET_LEVEL(ch,THIEF_LEVEL_IND) +1);
@@ -2297,7 +2296,7 @@ void do_levels(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
     if (HasClass(ch, CLASS_DRUID)) {
       exp = titles[DRUID_LEVEL_IND][GET_LEVEL(ch,DRUID_LEVEL_IND) + 1].exp;
-      sprintf(buf,
+      SPRINTF(buf,
               "You need %d experience points to become a level %d druid.\n\r",
 	      exp - GET_EXP(ch),
               GET_LEVEL(ch,DRUID_LEVEL_IND) +1);
@@ -2305,7 +2304,7 @@ void do_levels(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
     if (HasClass(ch, CLASS_MONK)) {
       exp = titles[MONK_LEVEL_IND][GET_LEVEL(ch,MONK_LEVEL_IND) + 1].exp;
-      sprintf(buf,
+      SPRINTF(buf,
               "You need %d experience points to become a level %d monk.\n\r",
               exp - GET_EXP(ch),
               GET_LEVEL(ch,MONK_LEVEL_IND) +1);
@@ -2345,7 +2344,7 @@ void do_levels(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     break;
 
   default:
-    sprintf(buf, "I don't recognize %s.\n\r", argument);
+    SPRINTF(buf, "I don't recognize %s.\n\r", argument);
     send_to_char(buf,ch);
     return;
     break;
@@ -2355,7 +2354,7 @@ void do_levels(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   
   for (i = 1; i <= RaceMax; i++) {
     
-    sprintf(buf, "[%2d] %9d-%-9d : %s\n\r", i,
+    SPRINTF(buf, "[%2d] %9d-%-9d : %s\n\r", i,
 	    titles[class][i].exp,
 	    titles[class][i + 1].exp, (GET_SEX(ch)==SEX_FEMALE?titles[class][i].title_f:titles[class][i].title_m));
     
@@ -2490,17 +2489,17 @@ void do_consider(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     num = GetApprox(GET_MAX_HIT(victim), learn);
     fnum = ((float)num/(float)GET_MAX_HIT(ch));
 
-    sprintf(buf, "Est Max hits are: %s\n\r", DescRatio(fnum));
+    SPRINTF(buf, "Est Max hits are: %s\n\r", DescRatio(fnum));
     send_to_char(buf, ch);
 
     num = GetApprox(GET_AC(victim), learn);
     fnum = ((float)num/(float)GET_AC(ch));
 
-    sprintf(buf, "Est. armor class is : %s\n\r", DescRatio(fnum));
+    SPRINTF(buf, "Est. armor class is : %s\n\r", DescRatio(fnum));
     send_to_char(buf, ch);
 
     if (learn > 60) {
-      sprintf(buf, "Est. # of attacks: %s\n\r", 
+      SPRINTF(buf, "Est. # of attacks: %s\n\r", 
 	      DescAttacks(GetApprox((int)victim->mult_att, 
 			 	  learn)));
       send_to_char(buf, ch);
@@ -2513,7 +2512,7 @@ void do_consider(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 			learn);
 
       fnum = (float)num*(num2/2.0);
-      sprintf(buf, "Est. damage of attacks is %s\n\r", 
+      SPRINTF(buf, "Est. damage of attacks is %s\n\r", 
 	      DescDamage(fnum));
             
       send_to_char(buf, ch);
@@ -2528,7 +2527,7 @@ void do_consider(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       else
 	fnum = 2.0;
 
-      sprintf(buf, "Est. Thaco: %s\n\r", DescRatio(fnum));
+      SPRINTF(buf, "Est. Thaco: %s\n\r", DescRatio(fnum));
 	    
       send_to_char(buf, ch);
 
@@ -2536,7 +2535,7 @@ void do_consider(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       num2 =  GET_DAMROLL(ch);
       fnum = (num/(float)num2);
 
-      sprintf(buf, "Est. Dam bonus is: %s\n\r", DescRatio(fnum));
+      SPRINTF(buf, "Est. Dam bonus is: %s\n\r", DescRatio(fnum));
 
       send_to_char(buf, ch);
     }
@@ -2563,7 +2562,7 @@ void do_spells(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     for (i = 1, spl = 0; i <= MAX_EXIST_SPELL; i++, spl++) { 
       if (GetMaxLevel(ch) > LOW_IMMORTAL || 
           skill_info[i].min_level[MIN_LEVEL_CLERIC] < ABS_MAX_LVL)
-	sprintf(buf + strlen(buf),
+        SAPPENDF(buf,
 		"[%2d] %-20s  Mana: %3d, Cl: %2d, Mu: %2d, Dr: %2d\n\r",
 		i, spells[spl], 
 		skill_info[i].min_usesmana, 
@@ -2617,7 +2616,7 @@ void do_spells(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       i=1;
       while( spell_data[i][1] <= RaceMax ) {
 	if(spell_data[i][1] > 0)
-	  sprintf(buf + strlen(buf),
+	  SAPPENDF(buf,
 		  "[%-3d] %-20s  %-2d            %-3d\n\r",
 		  spell_data[i][0],spells[spell_data[i][0]-1],
 		  skill_info[spell_data[i][0]].min_level[MIN_LEVEL_CLERIC],
@@ -2658,7 +2657,7 @@ void do_spells(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       i=1;
       while( spell_data[i][1] <= RaceMax ) {
         if(spell_data[i][1] > 0)
-          sprintf(buf + strlen(buf),
+          SAPPENDF(buf,
                   "[%-3d] %-20s  %-2d            %-3d\n\r",
                   spell_data[i][0],spells[spell_data[i][0]-1],
                   skill_info[spell_data[i][0]].min_level[MIN_LEVEL_MAGIC],
@@ -2702,7 +2701,7 @@ void do_spells(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       i=1;
       while( spell_data[i][1] <= RaceMax ) {
         if(spell_data[i][1] > 0)
-          sprintf(buf + strlen(buf),
+          SAPPENDF(buf,
                   "[%-3d] %-20s  %-2d            %-3d\n\r",
                   spell_data[i][0],spells[spell_data[i][0]-1],
                   skill_info[spell_data[i][0]].min_level[MIN_LEVEL_DRUID],
@@ -2731,41 +2730,41 @@ void do_world(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
   extern long mob_count;
   extern long obj_count;
 
-  sprintf(buf, "Base Source: SillyMUD Version %s.\n", VERSION);
+  SPRINTF(buf, "Base Source: SillyMUD Version %s.\n", VERSION);
   send_to_char(buf, ch);
   ot = Uptime;
   otmstr = asctime(localtime(&ot));
   *(otmstr + strlen(otmstr) - 1) = '\0';
-  sprintf(buf, "Start time was: %s (EST)\n\r", otmstr);
+  SPRINTF(buf, "Start time was: %s (EST)\n\r", otmstr);
   send_to_char(buf, ch);
   
   ct = time(0);
   tmstr = asctime(localtime(&ct));
   *(tmstr + strlen(tmstr) - 1) = '\0';
-  sprintf(buf, "Current time is: %s (EST)\n\r", tmstr);
+  SPRINTF(buf, "Current time is: %s (EST)\n\r", tmstr);
   send_to_char(buf, ch);
 #if HASH  
-  sprintf(buf, "Total number of rooms in world: %d\n\r", room_db.klistlen);
+  SPRINTF(buf, "Total number of rooms in world: %d\n\r", room_db.klistlen);
 #else
-  sprintf(buf, "Total number of rooms in world: %ld\n\r", room_count);
+  SPRINTF(buf, "Total number of rooms in world: %ld\n\r", room_count);
 #endif
   send_to_char(buf, ch);
-  sprintf(buf, "Total number of zones in world: %d\n\r\n\r",
+  SPRINTF(buf, "Total number of zones in world: %d\n\r\n\r",
 	  top_of_zone_table + 1);
   send_to_char(buf, ch);
-  sprintf(buf,"Total number of distinct mobiles in world: %d\n\r",
+  SPRINTF(buf,"Total number of distinct mobiles in world: %d\n\r",
 	  top_of_mobt + 1);
   send_to_char(buf, ch);
-  sprintf(buf,"Total number of distinct objects in world: %d\n\r\n\r",
+  SPRINTF(buf,"Total number of distinct objects in world: %d\n\r\n\r",
 	  top_of_objt + 1);
   send_to_char(buf, ch);
-  sprintf(buf,"Total number of registered players: %d\n\r",top_of_p_table + 1);
+  SPRINTF(buf,"Total number of registered players: %d\n\r",top_of_p_table + 1);
   send_to_char(buf, ch);
 
-  sprintf(buf, "Total number of monsters in game: %ld\n\r", mob_count);
+  SPRINTF(buf, "Total number of monsters in game: %ld\n\r", mob_count);
   send_to_char(buf, ch);
 
-  sprintf(buf, "Total number of objects in game: %ld\n\r", obj_count);
+  SPRINTF(buf, "Total number of objects in game: %ld\n\r", obj_count);
   send_to_char(buf, ch);
 
 }
@@ -2780,7 +2779,7 @@ void do_attribute(struct char_data *ch, char * UNUSED(argument),
 
   age2(ch, &my_age);
 
-  sprintf(buf,
+  SPRINTF(buf,
 	  "You are %d years and %d months, %d cms, and you weigh %d lbs.\n\r",
 	  my_age.year, my_age.month,
 	  ch->player.height,
@@ -2788,28 +2787,28 @@ void do_attribute(struct char_data *ch, char * UNUSED(argument),
 
   send_to_char(buf, ch);
   
-  sprintf(buf, "You are carrying %d lbs of equipment.\n\r",
+  SPRINTF(buf, "You are carrying %d lbs of equipment.\n\r",
 	  IS_CARRYING_W(ch));
   send_to_char(buf, ch); 
   
-  sprintf(buf,"You are %s \n\r",ArmorDesc(ch->points.armor));
+  SPRINTF(buf,"You are %s \n\r",ArmorDesc(ch->points.armor));
   send_to_char(buf,ch);
   
   if ((GetMaxLevel(ch) > 15) || (HasClass(ch, CLASS_MAGIC_USER) || 
 				 HasClass(ch, CLASS_MONK))) {
     if ((GET_STR(ch)==18) && (HasClass(ch, CLASS_WARRIOR))) {
-       sprintf(buf,"You have %d/%d STR, %d INT, %d WIS, %d DEX, %d CON, %d CHR\n\r",
+       SPRINTF(buf,"You have %d/%d STR, %d INT, %d WIS, %d DEX, %d CON, %d CHR\n\r",
 	    GET_STR(ch), GET_ADD(ch), GET_INT(ch), GET_WIS(ch), GET_DEX(ch), GET_CON(ch), GET_CHR(ch));
        send_to_char(buf,ch);
      } else {
-       sprintf(buf,"You have %d STR %d INT %d WIS %d DEX %d CON %d CHR\n\r",
+       SPRINTF(buf,"You have %d STR %d INT %d WIS %d DEX %d CON %d CHR\n\r",
 	    GET_STR(ch), GET_INT(ch), GET_WIS(ch), GET_DEX(ch), GET_CON(ch),
 	       GET_CHR(ch));
        send_to_char(buf,ch);
     }
   }  
 
-  sprintf(buf, "Your hit bonus and damage bonus are %s and %s respectively.\n\r",
+  SPRINTF(buf, "Your hit bonus and damage bonus are %s and %s respectively.\n\r",
 	  HitRollDesc(GET_HITROLL(ch)), DamRollDesc(GET_DAMROLL(ch)));
   send_to_char(buf, ch);
 
@@ -2826,7 +2825,7 @@ void do_attribute(struct char_data *ch, char * UNUSED(argument),
 	case SPELL_CURSE:
 	  break;
 	default:
-	  sprintf(buf, "Spell : '%s'\n\r",spells[aff->type-1]);
+	  SPRINTF(buf, "Spell : '%s'\n\r",spells[aff->type-1]);
 	  send_to_char(buf, ch);
 	  break;
 	}
@@ -2900,7 +2899,7 @@ void do_value(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
   }
 
-  sprintf(buf, "Object: %s.  Item type: ", obj->short_description);
+  SPRINTF(buf, "Object: %s.  Item type: ", obj->short_description);
   sprinttype(GET_ITEM_TYPE(obj),item_types,buf2);
   strcat(buf,buf2); strcat(buf,"\n\r");
   send_to_char(buf, ch);
@@ -2924,7 +2923,7 @@ void do_value(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     send_to_char(buf,ch);
   }
 
-  sprintf(buf,"Weight: %d, Value: %d, Ego: %d  %s\n\r",
+  SPRINTF(buf,"Weight: %d, Value: %d, Ego: %d  %s\n\r",
 	    obj->obj_flags.weight, 
 	  GetApprox(obj->obj_flags.cost, 
 		    ch->skills[SKILL_EVALUATE].learned-10), 
@@ -2934,7 +2933,7 @@ void do_value(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   send_to_char(buf, ch);
 
   if (ITEM_TYPE(obj) == ITEM_WEAPON) {
-    sprintf(buf, "Damage Dice is '%dD%d'\n\r",
+    SPRINTF(buf, "Damage Dice is '%dD%d'\n\r",
 	    GetApprox(obj->obj_flags.value[1],
 		      ch->skills[SKILL_EVALUATE].learned-10),
 	    GetApprox(obj->obj_flags.value[2],
@@ -2942,7 +2941,7 @@ void do_value(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     send_to_char(buf, ch);
   } else if (ITEM_TYPE(obj) == ITEM_ARMOR) {
 
-      sprintf(buf, "AC-apply is %d\n\r",
+      SPRINTF(buf, "AC-apply is %d\n\r",
 	      GetApprox(obj->obj_flags.value[0],
 			ch->skills[SKILL_EVALUATE].learned-10));
       send_to_char(buf, ch);
@@ -3201,7 +3200,7 @@ void ScreenOff(struct char_data *ch)
 {
  char buf[255];
 
- sprintf(buf, VT_MARGSET, 0, ch->size- 1);
+ SPRINTF(buf, VT_MARGSET, 0, ch->size- 1);
  send_to_char(buf, ch);
  send_to_char(VT_HOMECLR, ch);
 }
@@ -3267,7 +3266,7 @@ void do_report(struct char_data *ch, char * UNUSED(argument),
     return;
   }
 
-  sprintf(buf, "H:%d/%d    M:%d/%d    V:%d/%d   Exp:%d",
+  SPRINTF(buf, "H:%d/%d    M:%d/%d    V:%d/%d   Exp:%d",
 	  GET_HIT(ch), GET_MAX_HIT(ch), GET_MANA(ch), 
 	  GET_MAX_MANA(ch), GET_MOVE(ch), GET_MAX_MOVE(ch),
 	  GET_EXP(ch));
@@ -3294,7 +3293,7 @@ void list_groups(struct char_data *ch)
   /* list the master and the group name */
       if (!person->master && IS_AFFECTED(person, AFF_GROUP)) {
 	if (person->specials.gname && CAN_SEE(ch, person)) {
-	  sprintf(buf, "%s %s\n\r", fname (GET_NAME(person)), 
+	  SPRINTF(buf, "%s %s\n\r", fname (GET_NAME(person)), 
 		  person->specials.gname);
 	  send_to_char(buf, ch);
 	  /* list the members that ch can see */
@@ -3303,9 +3302,9 @@ void list_groups(struct char_data *ch)
 	    if (IS_AFFECTED(f->follower, AFF_GROUP) && IS_PC(f->follower)) {
 	      count++;
 	      if (CAN_SEE(ch, f->follower)) {
-		sprintf(buf, "          %s\n\r", fname(GET_NAME(f->follower)));
+		SPRINTF(buf, "          %s\n\r", fname(GET_NAME(f->follower)));
 	      } else {
-		sprintf(buf, "          Someone\n\r");
+		SPRINTF(buf, "          Someone\n\r");
 	      }
 	      send_to_char(buf, ch);
 	    }

--- a/src/act.move.c
+++ b/src/act.move.c
@@ -78,7 +78,7 @@ int ValidMove( struct char_data *ch, int cmd)
     if (exitp->keyword) {
       if (!IS_SET(exitp->exit_info, EX_SECRET) &&
 	  (strcmp(fname(exitp->keyword), "secret"))) {
-          sprintf(tmp, "The %s seems to be closed.\n\r",
+          SPRINTF(tmp, "The %s seems to be closed.\n\r",
 	      fname(exitp->keyword));
           send_to_char(tmp, ch);
           return(FALSE);
@@ -497,25 +497,25 @@ void DisplayMove( struct char_data *ch, int dir, int was_in, int total)
 	if (!IS_AFFECTED(ch, AFF_SILENCE) || number(0,2)) {
 	  if (total > 1) {
 	    if (IS_NPC(ch)) {
-	      sprintf(tmp,"%s %s %s. [%d]\n\r",ch->player.short_descr,how,
+	      SPRINTF(tmp,"%s %s %s. [%d]\n\r",ch->player.short_descr,how,
 		      dirs[dir], total);
 	    } else {
-	      sprintf(tmp,"%s %s %s. [%d]\n\r",GET_NAME(ch),how,dirs[dir],
+	      SPRINTF(tmp,"%s %s %s. [%d]\n\r",GET_NAME(ch),how,dirs[dir],
 		      total);
 	    }
 	  } else {
 	    if (IS_NPC(ch)) {
 	      if (MOUNTED(ch)) {
-		sprintf(tmp,"%s leaves %s, riding on %s\n\r",ch->player.short_descr, dirs[dir], MOUNTED(ch)->player.short_descr);
+		SPRINTF(tmp,"%s leaves %s, riding on %s\n\r",ch->player.short_descr, dirs[dir], MOUNTED(ch)->player.short_descr);
 	      } else {
-		sprintf(tmp,"%s %s %s.\n\r",ch->player.short_descr,how,
+		SPRINTF(tmp,"%s %s %s.\n\r",ch->player.short_descr,how,
 			dirs[dir]);
 	      }
 	    } else {
 	      if (MOUNTED(ch)) {
-		sprintf(tmp,"%s leaves %s, riding on %s\n\r",GET_NAME(ch), dirs[dir], MOUNTED(ch)->player.short_descr);
+		SPRINTF(tmp,"%s leaves %s, riding on %s\n\r",GET_NAME(ch), dirs[dir], MOUNTED(ch)->player.short_descr);
 	      } else {
-		sprintf(tmp,"%s %s %s.\n\r",GET_NAME(ch),how,dirs[dir]);
+		SPRINTF(tmp,"%s %s %s.\n\r",GET_NAME(ch),how,dirs[dir]);
 	      }
 	    }
 	  }
@@ -535,62 +535,63 @@ void DisplayMove( struct char_data *ch, int dir, int was_in, int total)
 	if (dir < 4) {
 	  if (total == 1) {
 	    if (MOUNTED(ch)) {
-	      sprintf(tmp, "%s from the %s, riding on %s", 
+	      SPRINTF(tmp, "%s from the %s, riding on %s", 
 		      PERS(ch, tmp_ch),dirs[rev_dir[dir]], 
 		      PERS(MOUNTED(ch), tmp_ch));
 	    } else {
-	      sprintf(tmp, "%s %s from the %s.", 
+	      SPRINTF(tmp, "%s %s from the %s.", 
 		      PERS(ch, tmp_ch),how,dirs[rev_dir[dir]]);
 	    }
 	  } else {
-	      sprintf(tmp, "%s %s from the %s.", 
+	      SPRINTF(tmp, "%s %s from the %s.", 
 		      PERS(ch, tmp_ch),how,dirs[rev_dir[dir]]);
 	  }
 	} else if (dir == 4) {
 	  if (total == 1) {
 	    if (MOUNTED(ch)) {
-	      sprintf(tmp, "%s has arrived from below, riding on %s", 
+	      SPRINTF(tmp, "%s has arrived from below, riding on %s", 
 		      PERS(ch, tmp_ch), 
 		      PERS(MOUNTED(ch), tmp_ch));
 	    } else {
-	      sprintf(tmp, "%s %s from below.", 
+	      SPRINTF(tmp, "%s %s from below.", 
 		      PERS(ch, tmp_ch),how);
 	    }
 	  } else {
-	    sprintf(tmp, "%s %s from below.", 
+	    SPRINTF(tmp, "%s %s from below.", 
 		    PERS(ch, tmp_ch),how);
 	  }
 	} else if (dir == 5) {
 	  if (total == 1) {
 	    if (MOUNTED(ch)) {
-	      sprintf(tmp, "%s has arrived from above, riding on %s", 
+	      SPRINTF(tmp, "%s has arrived from above, riding on %s", 
 		      PERS(ch, tmp_ch), 
 		      PERS(MOUNTED(ch), tmp_ch));
 	    } else {
-	      sprintf(tmp, "%s %s from above", 
+	      SPRINTF(tmp, "%s %s from above", 
 		      PERS(ch, tmp_ch),how);
 	    }
 	  } else {
-	    sprintf(tmp, "%s %s from above.", 
+	    SPRINTF(tmp, "%s %s from above.", 
 		    PERS(ch, tmp_ch),how);
 	  }
 	} else {
 	  if (total == 1) {
 	    if (MOUNTED(ch)) {
-	      sprintf(tmp, "%s has arrived from somewhere, riding on %s", 
+	      SPRINTF(tmp, "%s has arrived from somewhere, riding on %s", 
 		      PERS(ch, tmp_ch), 
 		      PERS(MOUNTED(ch), tmp_ch));
 	    } else {
-	      sprintf(tmp, "%s has arrived from somewhere.", 
+	      SPRINTF(tmp, "%s has arrived from somewhere.", 
 		      PERS(ch, tmp_ch));
 	    }
 	  } else {
-	    sprintf(tmp, "%s has arrived from somewhere.", 
+	    SPRINTF(tmp, "%s has arrived from somewhere.", 
 		    PERS(ch, tmp_ch));
 	  }
 	}
 	if (total > 1) {
-	  sprintf(tmp+strlen(tmp), " [%d]", total);
+	  snprintf(tmp+strlen(tmp), sizeof(tmp) - strlen(tmp) - 1,
+               " [%d]", total);
 	}
 	strcat(tmp, "\n\r");
 	send_to_char(tmp, tmp_ch);
@@ -655,7 +656,7 @@ int find_door(struct char_data *ch, char *type, char *dir)
 	  send_to_char("Thats a direction, not a portal.\n\r", ch);
 	  return(-1);
 	}
-	sprintf(buf, "I see no %s there.\n\r", type);
+	SPRINTF(buf, "I see no %s there.\n\r", type);
 	send_to_char(buf, ch);
 	return(-1);
       }
@@ -664,7 +665,7 @@ int find_door(struct char_data *ch, char *type, char *dir)
 	send_to_char("Thats a direction, not a portal.\n\r", ch);
 	return(-1);
       }
-      sprintf(buf, "I see no %s there.\n\r", type);
+      SPRINTF(buf, "I see no %s there.\n\r", type);
       send_to_char(buf, ch);
       return(-1);
     }
@@ -681,7 +682,7 @@ int find_door(struct char_data *ch, char *type, char *dir)
 	return(-1);
       }
     }
-    sprintf(buf, "I see no %s here.\n\r", type);
+    SPRINTF(buf, "I see no %s here.\n\r", type);
     send_to_char(buf, ch);
     return(-1);
   }
@@ -697,7 +698,7 @@ void open_door(struct char_data *ch, int dir)
   
   rp = real_roomp(ch->in_room);
   if (rp==NULL) {
-    sprintf(buf, "NULL rp in open_door() for %s.", PERS(ch,ch));
+    SPRINTF(buf, "NULL rp in open_door() for %s.", PERS(ch,ch));
     log_msg(buf);
   }
   
@@ -707,7 +708,7 @@ void open_door(struct char_data *ch, int dir)
   if (exitp->keyword) {
     if (strcmp(fname(exitp->keyword), "secret") &&
 	(!IS_SET(exitp->exit_info, EX_SECRET))) {
-      sprintf(buf, "$n opens the %s", fname(exitp->keyword));
+      SPRINTF(buf, "$n opens the %s", fname(exitp->keyword));
       act(buf, FALSE, ch, 0, 0, TO_ROOM);
     } else {
       act("$n reveals a hidden passage!", FALSE, ch, 0, 0, TO_ROOM);
@@ -721,7 +722,7 @@ void open_door(struct char_data *ch, int dir)
       (back->to_room == ch->in_room))    {
       REMOVE_BIT(back->exit_info, EX_CLOSED);
       if (back->keyword && (strcmp("secret", fname(back->keyword))))	{
-	sprintf(buf, "The %s is opened from the other side.\n\r",
+	SPRINTF(buf, "The %s is opened from the other side.\n\r",
 		fname(back->keyword));
 	send_to_room(buf, exitp->to_room);
       } else {
@@ -740,7 +741,7 @@ void raw_open_door(struct char_data *ch, int dir)
   
   rp = real_roomp(ch->in_room);
   if (rp==NULL) {
-    sprintf(buf, "NULL rp in open_door() for %s.", PERS(ch,ch));
+    SPRINTF(buf, "NULL rp in open_door() for %s.", PERS(ch,ch));
     log_msg(buf);
   }
   
@@ -753,7 +754,7 @@ void raw_open_door(struct char_data *ch, int dir)
       (back->to_room == ch->in_room))    {
       REMOVE_BIT(back->exit_info, EX_CLOSED);
       if (back->keyword && (strcmp("secret", fname(back->keyword))))	{
-	sprintf(buf, "The %s is opened from the other side.\n\r",
+	SPRINTF(buf, "The %s is opened from the other side.\n\r",
 		fname(back->keyword));
 	send_to_room(buf, exitp->to_room);
       } else {
@@ -861,7 +862,7 @@ void do_close(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	  (back->to_room == ch->in_room) ) {
 	SET_BIT(back->exit_info, EX_CLOSED);
 	if (back->keyword)    {	      
-	  sprintf(buf, "The %s closes quietly.\n\r", back->keyword);
+	  SPRINTF(buf, "The %s closes quietly.\n\r", back->keyword);
 	  send_to_room(buf, exitp->to_room);
 	}
 	else
@@ -903,7 +904,7 @@ void raw_unlock_door( struct char_data *ch,
       back->to_room == ch->in_room) {
     REMOVE_BIT(back->exit_info, EX_LOCKED);
   } else {
-    sprintf(buf, "Inconsistent door locks in rooms %d->%d", 
+    SPRINTF(buf, "Inconsistent door locks in rooms %d->%d", 
 	    ch->in_room, exitp->to_room);
     log_msg(buf);
   }
@@ -924,7 +925,7 @@ void raw_lock_door( struct char_data *ch,
       back->to_room == ch->in_room) {
     SET_BIT(back->exit_info, EX_LOCKED);
   } else {
-    sprintf(buf, "Inconsistent door locks in rooms %d->%d", 
+    SPRINTF(buf, "Inconsistent door locks in rooms %d->%d", 
 	    ch->in_room, exitp->to_room);
     log_msg(buf);
   }
@@ -1151,7 +1152,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	do_move(ch, "", ++door);
 	return;
       }
-    sprintf(tmp, "There is no %s here.\n\r", buf);
+    SPRINTF(tmp, "There is no %s here.\n\r", buf);
     send_to_char(tmp, ch);
   } else if (IS_SET(real_roomp(ch->in_room)->room_flags, INDOORS)) {
     send_to_char("You are already indoors.\n\r", ch);

--- a/src/act.obj1.c
+++ b/src/act.obj1.c
@@ -55,14 +55,14 @@ void get(struct char_data *ch, struct obj_data *obj_object,
     if (obj_object->obj_flags.value[0]<1)
       obj_object->obj_flags.value[0] = 1;
     obj_from_char(obj_object);
-    sprintf(buffer,"There %s %d coins.\n\r", 
+    SPRINTF(buffer,"There %s %d coins.\n\r", 
 	    obj_object->obj_flags.value[0] > 1 ? "were" : "was",
 	    obj_object->obj_flags.value[0]);
     send_to_char(buffer,ch);
     GET_GOLD(ch) += obj_object->obj_flags.value[0];
     if (GET_GOLD(ch) > 100000 && obj_object->obj_flags.value[0] > 10000) {
       char buf[MAX_INPUT_LENGTH];
-      sprintf(buf,"%s just got %d coins!",
+      SPRINTF(buf,"%s just got %d coins!",
 	      GET_NAME(ch),obj_object->obj_flags.value[0]);
       log_msg(buf);
     }
@@ -145,13 +145,13 @@ void do_get(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	      fail = TRUE;
 	    }
 	  } else {
-	    sprintf(buffer,"%s : You can't carry that much weight.\n\r", 
+	    SPRINTF(buffer,"%s : You can't carry that much weight.\n\r", 
 		    obj_object->short_description);
 	    send_to_char(buffer, ch);
 	    fail = TRUE;
 	  }
 	} else {
-	  sprintf(buffer,"%s : You can't carry that many items.\n\r", obj_object->short_description);
+	  SPRINTF(buffer,"%s : You can't carry that many items.\n\r", obj_object->short_description);
 	  send_to_char(buffer, ch);
 	  fail = TRUE;
 	}
@@ -194,14 +194,14 @@ void do_get(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	      num = 0;
 	    }
 	  } else {
-	    sprintf(buffer,"%s : You can't carry that much weight.\n\r", 
+	    SPRINTF(buffer,"%s : You can't carry that much weight.\n\r", 
 		    obj_object->short_description);
 	    send_to_char(buffer, ch);
 	    fail = TRUE;
 	    num = 0;
 	  }
 	} else {
-	  sprintf(buffer,"%s : You can't carry that many items.\n\r", 
+	  SPRINTF(buffer,"%s : You can't carry that many items.\n\r", 
 		  obj_object->short_description);
 	  send_to_char(buffer, ch);
 	  fail = TRUE;
@@ -209,7 +209,7 @@ void do_get(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	}
       } else {
 	if (num > 0) {
-	  sprintf(buffer,"You do not see a %s here.\n\r", arg1);
+	  SPRINTF(buffer,"You do not see a %s here.\n\r", arg1);
 	  send_to_char(buffer, ch);
 	}
 	num = 0;
@@ -254,13 +254,13 @@ void do_get(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 		  fail = TRUE;
 		}
 	      } else {
-		sprintf(buffer,"%s : You can't carry that much weight.\n\r", 
+		SPRINTF(buffer,"%s : You can't carry that much weight.\n\r", 
 			obj_object->short_description);
 		send_to_char(buffer, ch);
 		fail = TRUE;
 	      }
 	    } else {
-	      sprintf(buffer,"%s : You can't carry that many items.\n\r", 
+	      SPRINTF(buffer,"%s : You can't carry that many items.\n\r", 
 		      obj_object->short_description);
 	      send_to_char(buffer, ch);
 	      fail = TRUE;
@@ -268,19 +268,19 @@ void do_get(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	  }
 	}
 	if (!found && !fail) {
-	  sprintf(buffer,"You do not see anything in %s.\n\r", 
+	  SPRINTF(buffer,"You do not see anything in %s.\n\r", 
 		  sub_object->short_description);
 	  send_to_char(buffer, ch);
 	  fail = TRUE;
 	}
       } else {
-	sprintf(buffer,"%s is not a container.\n\r",
+	SPRINTF(buffer,"%s is not a container.\n\r",
 		sub_object->short_description);
 	send_to_char(buffer, ch);
 	fail = TRUE;
       }
     } else { 
-      sprintf(buffer,"You do not see or have the %s.\n\r", arg2);
+      SPRINTF(buffer,"You do not see or have the %s.\n\r", arg2);
       send_to_char(buffer, ch);
       fail = TRUE;
     }
@@ -334,14 +334,14 @@ void do_get(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 		  num = 0;
 		}
 	      } else {
-		sprintf(buffer,"%s : You can't carry that much weight.\n\r", 
+		SPRINTF(buffer,"%s : You can't carry that much weight.\n\r", 
 			obj_object->short_description);
 		send_to_char(buffer, ch);
 		fail = TRUE;
 		num = 0;
 	      }
 	    } else {
-	      sprintf(buffer,"%s : You can't carry that many items.\n\r", 
+	      SPRINTF(buffer,"%s : You can't carry that many items.\n\r", 
 		      obj_object->short_description);
 	      send_to_char(buffer, ch);
 	      fail = TRUE;
@@ -349,7 +349,7 @@ void do_get(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	    }
 	  } else {
 	    if (num > 0) {
-	      sprintf(buffer,"%s does not contain the %s.\n\r",sub_object->short_description, arg1);
+	      SPRINTF(buffer,"%s does not contain the %s.\n\r",sub_object->short_description, arg1);
 	      send_to_char(buffer, ch);
 	    }
 	    num = 0;
@@ -360,12 +360,12 @@ void do_get(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	  
 	}
       } else {
-	sprintf(buffer,"%s is not a container.\n\r", sub_object->short_description);
+	SPRINTF(buffer,"%s is not a container.\n\r", sub_object->short_description);
 	send_to_char(buffer, ch);
 	fail = TRUE;
       }
     } else {
-      sprintf(buffer,"You do not see or have the %s.\n\r", arg2);
+      SPRINTF(buffer,"You do not see or have the %s.\n\r", arg2);
       send_to_char(buffer, ch);
       fail = TRUE;
     }
@@ -429,9 +429,9 @@ void do_drop(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	} else {
 	  if (CAN_SEE_OBJ(ch, tmp_object)) {
 	    if (singular(tmp_object)) 
-	      sprintf(buffer, "You can't drop %s, it must be CURSED!\n\r", tmp_object->short_description);
+	      SPRINTF(buffer, "You can't drop %s, it must be CURSED!\n\r", tmp_object->short_description);
 	    else 
-	      sprintf(buffer, "You can't drop %s, they must be CURSED!\n\r", tmp_object->short_description);
+	      SPRINTF(buffer, "You can't drop %s, they must be CURSED!\n\r", tmp_object->short_description);
 	    send_to_char(buffer, ch);
 	    test = TRUE;
 	  }
@@ -462,7 +462,7 @@ void do_drop(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	tmp_object = get_obj_in_list_vis(ch, arg, ch->carrying);
 	if (tmp_object) {
 	  if (! IS_SET(tmp_object->obj_flags.extra_flags, ITEM_NODROP)) {
-	    sprintf(buffer, "You drop %s.\n\r", tmp_object->short_description);
+	    SPRINTF(buffer, "You drop %s.\n\r", tmp_object->short_description);
 	    send_to_char(buffer, ch);
 	    act("$n drops $p.", 1, ch, tmp_object, 0, TO_ROOM);
 	    obj_from_char(tmp_object);
@@ -592,18 +592,18 @@ void do_put(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 		  num = 0;
 		}
 	      } else {
-		sprintf(buffer,"%s is not a container.\n\r", sub_object->short_description);
+		SPRINTF(buffer,"%s is not a container.\n\r", sub_object->short_description);
 		send_to_char(buffer, ch);
 		num = 0;
 	      }
 	    } else {
-	      sprintf(buffer, "You don't have the %s.\n\r", arg2);
+	      SPRINTF(buffer, "You don't have the %s.\n\r", arg2);
 	      send_to_char(buffer, ch);
 	      num = 0;
 	    }
 	  } else {
 	    if ((num > 0) || (num == -1)) { 
-	      sprintf(buffer, "You don't have the %s.\n\r", arg1);
+	      SPRINTF(buffer, "You don't have the %s.\n\r", arg1);
 	      send_to_char(buffer, ch);
 	    }
 	    num = 0;
@@ -614,7 +614,7 @@ void do_put(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 #endif
       }
     } else {
-      sprintf(buffer, "Put %s in what?\n\r", arg1);
+      SPRINTF(buffer, "Put %s in what?\n\r", arg1);
       send_to_char(buffer, ch);
     }
   } else {
@@ -637,7 +637,7 @@ void do_give(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   struct obj_data *obj;
   
   argument=one_argument(argument,obj_name);
-  sprintf(buf,"obj_name: %s",obj_name);
+  SPRINTF(buf,"obj_name: %s",obj_name);
   if(is_number(obj_name))	{
     if(newstrlen(obj_name) >= 10)
       obj_name[10] = '\0';
@@ -669,7 +669,7 @@ void do_give(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
 
     send_to_char("Ok.\n\r",ch);
-    sprintf(buf,"%s gives you %d gold coins.\n\r",PERS(ch,vict),amount);
+    SPRINTF(buf,"%s gives you %d gold coins.\n\r",PERS(ch,vict),amount);
     send_to_char(buf,vict);
     act("$n gives some gold to $N.", 1, ch, 0, vict, TO_NOTVICT);
     if (IS_NPC(ch) || (GetMaxLevel(ch) < DEMIGOD))
@@ -677,7 +677,7 @@ void do_give(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     GET_GOLD(vict)+=amount;
     save_char(ch, AUTO_RENT);
     if ((GET_GOLD(vict) > 500000) && (amount > 100000)) {
-      sprintf(buf, "%s gave %d coins to %s", GET_NAME(ch), amount, GET_NAME(vict));
+      SPRINTF(buf, "%s gave %d coins to %s", GET_NAME(ch), amount, GET_NAME(vict));
       log_msg(buf);
     }
       

--- a/src/act.obj2.c
+++ b/src/act.obj2.c
@@ -32,10 +32,10 @@ void weight_change_object(struct obj_data *obj, int weight)
   if (GET_OBJ_WEIGHT(obj) + weight < 1) {
       weight = 0 - (GET_OBJ_WEIGHT(obj) -1);
       if (obj->carried_by) {
-	sprintf(buf,"Bad weight change on %s, carried by %s.",obj->name,obj->carried_by->player.name);
+	SPRINTF(buf,"Bad weight change on %s, carried by %s.",obj->name,obj->carried_by->player.name);
 	log_msg(buf);
       } else {
-	sprintf(buf,"Bad weight change on %s.",obj->name);
+	SPRINTF(buf,"Bad weight change on %s.",obj->name);
 	log_msg(buf);
       }
   }
@@ -79,7 +79,7 @@ void name_to_drinkcon(struct obj_data *obj,int type)
   extern char *drinknames[];
   
   CREATE(new_name,char,strlen(obj->name)+strlen(drinknames[type])+2);
-  sprintf(new_name,"%s %s",drinknames[type],obj->name);
+  SPRINTF(new_name,"%s %s",drinknames[type],obj->name);
   free(obj->name);
   obj->name=new_name;
 }
@@ -117,9 +117,9 @@ void do_drink(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   
   if (temp->obj_flags.type_flag==ITEM_DRINKCON){
     if (temp->obj_flags.value[1]>0)  /* Not empty */ {
-      sprintf(buf,"$n drinks %s from $p",drinks[temp->obj_flags.value[2]]);
+      SPRINTF(buf,"$n drinks %s from $p",drinks[temp->obj_flags.value[2]]);
       act(buf, TRUE, ch, temp, 0, TO_ROOM);
-      sprintf(buf,"You drink the %s.\n\r",drinks[temp->obj_flags.value[2]]);
+      SPRINTF(buf,"You drink the %s.\n\r",drinks[temp->obj_flags.value[2]]);
       send_to_char(buf,ch);
       
       if (drink_aff[temp->obj_flags.value[2]][DRUNK] > 0 )
@@ -322,7 +322,7 @@ void do_pour(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     return;
   }
   
-  sprintf(buf,"You pour the %s into the %s.",
+  SPRINTF(buf,"You pour the %s into the %s.",
 	  drinks[from_obj->obj_flags.value[2]],arg2);
   send_to_char(buf,ch);
   
@@ -387,7 +387,7 @@ void do_sip(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
   
   act("$n sips from the $o",TRUE,ch,temp,0,TO_ROOM);
-  sprintf(buf,"It tastes like %s.\n\r",drinks[temp->obj_flags.value[2]]);
+  SPRINTF(buf,"It tastes like %s.\n\r",drinks[temp->obj_flags.value[2]]);
   send_to_char(buf,ch);
   
   gain_condition(ch,DRUNK,(int)(drink_aff[temp->obj_flags.value[2]]
@@ -677,13 +677,13 @@ void wear(struct char_data *ch, struct obj_data *obj_object, int keyword)
       } else {
 	perform_wear(ch,obj_object,keyword);
 	if (ch->equipment[WEAR_FINGER_L]) {
-	  sprintf(buffer, "You put %s on your right finger.\n\r",
+	  SPRINTF(buffer, "You put %s on your right finger.\n\r",
 		  obj_object->short_description);
 	  send_to_char(buffer, ch);
 	  obj_from_char(obj_object);
 	  equip_char(ch, obj_object, WEAR_FINGER_R);
 	} else {
-	  sprintf(buffer, "You put %s on your left finger.\n\r", 
+	  SPRINTF(buffer, "You put %s on your left finger.\n\r", 
 		  obj_object->short_description);
 	  send_to_char(buffer, ch);
 	  obj_from_char(obj_object);
@@ -835,12 +835,12 @@ void wear(struct char_data *ch, struct obj_data *obj_object, int keyword)
 	perform_wear(ch,obj_object,keyword);
 	obj_from_char(obj_object);
 	if (ch->equipment[WEAR_WRIST_L]) {
-	  sprintf(buffer, "You wear %s around your right wrist.\n\r", 
+	  SPRINTF(buffer, "You wear %s around your right wrist.\n\r", 
 		  obj_object->short_description);
 	  send_to_char(buffer, ch);
 	  equip_char(ch,  obj_object, WEAR_WRIST_R);
 	} else {
-	  sprintf(buffer, "You wear %s around your left wrist.\n\r", 	
+	  SPRINTF(buffer, "You wear %s around your left wrist.\n\r", 	
 		  obj_object->short_description);
 	  send_to_char(buffer, ch);
 	  equip_char(ch, obj_object, WEAR_WRIST_L);
@@ -937,7 +937,7 @@ void wear(struct char_data *ch, struct obj_data *obj_object, int keyword)
 	    send_to_char("You cannot wield a two handed weapon and wear a shield.\n\r", ch);
       } else {
 	perform_wear(ch,obj_object,keyword);
-	sprintf(buffer, "You start using %s.\n\r", 
+	SPRINTF(buffer, "You start using %s.\n\r", 
 		obj_object->short_description);
 	send_to_char(buffer, ch);
 	obj_from_char(obj_object);
@@ -948,11 +948,11 @@ void wear(struct char_data *ch, struct obj_data *obj_object, int keyword)
     }
   } break;
   case -1: {
-    sprintf(buffer,"Wear %s where?.\n\r", obj_object->short_description);
+    SPRINTF(buffer,"Wear %s where?.\n\r", obj_object->short_description);
     send_to_char(buffer, ch);
   } break;
   case -2: {
-    sprintf(buffer,"You can't wear %s.\n\r", obj_object->short_description);
+    SPRINTF(buffer,"You can't wear %s.\n\r", obj_object->short_description);
     send_to_char(buffer, ch);
   } break;
   default: {
@@ -1009,7 +1009,7 @@ void do_wear(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	if (CAN_WEAR(obj_object,ITEM_HOLD)) keyword = 13;
 	
 	if (keyword != -2) {
-	  sprintf(buf,"%s :", obj_object->short_description);
+	  SPRINTF(buf,"%s :", obj_object->short_description);
 	  send_to_char(buf,ch);
 	  wear(ch, obj_object, keyword);
 	}
@@ -1021,10 +1021,10 @@ void do_wear(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	if (*arg2) {
 	  keyword = search_block(arg2, keywords, FALSE); /* Partial Match */
 	  if (keyword == -1) {
-	    sprintf(buf, "%s is an unknown body location.\n\r", arg2);
+	    SPRINTF(buf, "%s is an unknown body location.\n\r", arg2);
 	    send_to_char(buf, ch);
 	  } else {
-	  sprintf(buf,"%s :", obj_object->short_description);
+	  SPRINTF(buf,"%s :", obj_object->short_description);
 	  send_to_char(buf,ch);
 	    wear(ch, obj_object, keyword+1);
 	  }
@@ -1043,12 +1043,12 @@ void do_wear(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	  if (CAN_WEAR(obj_object,ITEM_WEAR_HEAD)) keyword = 4;
 	  if (CAN_WEAR(obj_object,ITEM_WEAR_BODY)) keyword = 3;
 	  
-	  sprintf(buf,"%s :", obj_object->short_description);
+	  SPRINTF(buf,"%s :", obj_object->short_description);
 	  send_to_char(buf,ch);
 	  wear(ch, obj_object, keyword);
 	}
       } else {
-	sprintf(buffer, "You do not seem to have the '%s'.\n\r",arg1);
+	SPRINTF(buffer, "You do not seem to have the '%s'.\n\r",arg1);
 	send_to_char(buffer,ch);
       }
     }
@@ -1070,7 +1070,7 @@ void do_wield(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     if (obj_object) {
       wear(ch, obj_object, keyword);
     } else {
-      sprintf(buffer, "You do not seem to have the '%s'.\n\r",arg1);
+      SPRINTF(buffer, "You do not seem to have the '%s'.\n\r",arg1);
       send_to_char(buffer,ch);
     }
   } else {
@@ -1094,7 +1094,7 @@ void do_grab(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       else
 	wear(ch, obj_object, 13);
     } else {
-      sprintf(buffer, "You do not seem to have the '%s'.\n\r",arg1);
+      SPRINTF(buffer, "You do not seem to have the '%s'.\n\r",arg1);
       send_to_char(buffer,ch);
     }
   } else {
@@ -1176,7 +1176,7 @@ void do_remove(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	    j = MAX_WEAR;
 	  }
 	} else 	{
-	  sprintf(buffer,"You dont seem to have the %s\n\r",T);
+	  SPRINTF(buffer,"You dont seem to have the %s\n\r",T);
 	  send_to_char(buffer,ch);
 	}
 	if (T != P) T = P + 1;

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -299,7 +299,7 @@ void do_order(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     if (victim) {
 	if (check_soundproof(victim))
 	  return;
-      sprintf(buf, "$N orders you to '%s'", message);
+      SPRINTF(buf, "$N orders you to '%s'", message);
       act(buf, FALSE, victim, 0, ch, TO_CHAR);
       act("$n gives $N an order.", FALSE, ch, 0, victim, TO_ROOM);
       
@@ -333,7 +333,7 @@ void do_order(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	command_interpreter(victim, message);
       }
     } else {  /* This is order "followers" */
-      sprintf(buf, "$n issues the order '%s'.", message);
+      SPRINTF(buf, "$n issues the order '%s'.", message);
       act(buf, FALSE, ch, 0, victim, TO_ROOM);
       
       org_room = ch->in_room;
@@ -373,7 +373,7 @@ void do_flee(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   if(IS_PC(ch) || IS_SET(ch->specials.act, ACT_POLYSELF)) {
     if((ch->desc->wait)>1) {      /* Someone is in a wait state */
       send_to_char("Your head is still spinning too much to flee!\n\r", ch);
-      sprintf(buf, "You must wait %d pulses\n\r", ch->desc->wait);
+      SPRINTF(buf, "You must wait %d pulses\n\r", ch->desc->wait);
       send_to_char(buf, ch);
       return;
     }
@@ -389,10 +389,10 @@ void do_flee(struct char_data *ch, char *argument, int UNUSED(cmd)) {
          send_to_char("Please choose a flee setting of 1 to 5 rooms.\n\r", ch);
          return;
        }
-       sprintf(buf2,"You used to flee %d rooms when you ran away.\n\r",ch->specials.flee);
+       SPRINTF(buf2,"You used to flee %d rooms when you ran away.\n\r",ch->specials.flee);
        send_to_char(buf2,ch);
        ch->specials.flee = nmbr;
-       sprintf(buf2,"You will NOW flee %d rooms when you run away.\n\r",ch->specials.flee);
+       SPRINTF(buf2,"You will NOW flee %d rooms when you run away.\n\r",ch->specials.flee);
        send_to_char(buf2,ch);
        return;
     }
@@ -1169,7 +1169,7 @@ void do_wimp(struct char_data *ch, char *argument, int UNUSED(cmd)) {
         REMOVE_BIT(ch->specials.act, PLR_WIMPY);
       send_to_char("Ok, you are no longer a wimp...\n\r",ch);
       ch->specials.pct = pct;
-      sprintf(buf2,"And you will now get your BLEEDING message at %d%% of max hitpoints.\n\r",ch->specials.pct);
+      SPRINTF(buf2,"And you will now get your BLEEDING message at %d%% of max hitpoints.\n\r",ch->specials.pct);
       send_to_char(buf2,ch);
     }
     else {
@@ -1178,7 +1178,7 @@ void do_wimp(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       else
         REMOVE_BIT(ch->specials.act, PLR_WIMPY);
       send_to_char("Ok, you are no longer a wimp...\n\r",ch);
-      sprintf(buf2,"However, you will still get your BLEEDING message at %d%% of max hitpoints.\n\r",ch->specials.pct);
+      SPRINTF(buf2,"However, you will still get your BLEEDING message at %d%% of max hitpoints.\n\r",ch->specials.pct);
       send_to_char(buf2,ch);
     }
   } else {
@@ -1192,15 +1192,15 @@ void do_wimp(struct char_data *ch, char *argument, int UNUSED(cmd)) {
         send_to_char("Please choose a value between 1 and 50.\n\r",ch);
         return;
       }
-      sprintf(buf2,"Your wimpy percentage WAS %d%%.\n\r",ch->specials.pct);
+      SPRINTF(buf2,"Your wimpy percentage WAS %d%%.\n\r",ch->specials.pct);
       send_to_char(buf2,ch);
       ch->specials.pct = pct;
-      sprintf(buf2,"Your wimpy percentage has now been set to %d%%.\n\r",
+      SPRINTF(buf2,"Your wimpy percentage has now been set to %d%%.\n\r",
 	      ch->specials.pct);
       send_to_char(buf2,ch);
     }
     else {
-      sprintf(buf2,"Your wimpy percentage remains at %d%%.\n\r",
+      SPRINTF(buf2,"Your wimpy percentage remains at %d%%.\n\r",
 	      ch->specials.pct);
       send_to_char(buf2,ch);
     }
@@ -1254,7 +1254,7 @@ void do_breath(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       ;
     
     if (count<1) {
-      sprintf(buf, "monster %s has no breath weapons",
+      SPRINTF(buf, "monster %s has no breath weapons",
 	      ch->player.short_descr);
       log_msg(buf);
       send_to_char("Hey, why don't you have any breath weapons!?\n\r",ch);

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -109,14 +109,14 @@ void do_junk(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
   }
   if (count > 1) {
-    sprintf(buf, "You junk %s (%d).\n\r", arg, count);
+    SPRINTF(buf, "You junk %s (%d).\n\r", arg, count);
     act(buf, 1, ch, 0, 0, TO_CHAR);
-    sprintf(buf, "$n junks %s.\n\r", arg);
+    SPRINTF(buf, "$n junks %s.\n\r", arg);
     act(buf, 1, ch, 0, 0, TO_ROOM);
   } else if (count == 1) {
-    sprintf(buf, "You junk %s \n\r", arg);
+    SPRINTF(buf, "You junk %s \n\r", arg);
     act(buf, 1, ch, 0, 0, TO_CHAR);
-    sprintf(buf, "$n junks %s.\n\r", arg);
+    SPRINTF(buf, "$n junks %s.\n\r", arg);
     act(buf, 1, ch, 0, 0, TO_ROOM);
   } else {
     send_to_char("You don't have anything like that\n\r", ch);
@@ -156,7 +156,7 @@ void do_title(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       send_to_char("Line too long, truncated\n", ch);
       *(argument + 151) = '\0';
     }
-    sprintf(buf, "Your title has been set to : <%s>\n\r", argument);
+    SPRINTF(buf, "Your title has been set to : <%s>\n\r", argument);
     send_to_char(buf, ch);
     free(ch->player.title);
     ch->player.title = strdup(argument);
@@ -178,7 +178,7 @@ void do_quit(struct char_data *ch, char * UNUSED(argument), int UNUSED(cmd)) {
   
   if (GET_POS(ch) < POSITION_STUNNED) {
     send_to_char("You die before your time!\n\r", ch);
-    sprintf(buf, "%s dies via quit.", GET_NAME(ch));
+    SPRINTF(buf, "%s dies via quit.", GET_NAME(ch));
     log_msg(buf);
     die(ch);    
     return;
@@ -435,7 +435,7 @@ void do_steal(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   
   if(GetMaxLevel(victim) > 50) {
     send_to_char("Steal from a God?!?  Oh the thought!\n\r", ch);
-    sprintf(buf, "BUG NOTE: %s tried to steal from GOD %s", GET_NAME(ch), GET_NAME(victim));
+    SPRINTF(buf, "BUG NOTE: %s tried to steal from GOD %s", GET_NAME(ch), GET_NAME(victim));
     log_msg(buf);
     return;
   }
@@ -549,7 +549,7 @@ void do_steal(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       if (gold > 0) {
 	GET_GOLD(ch) += gold;
 	GET_GOLD(victim) -= gold;
-	sprintf(buf, "Bingo! You got %d gold coins.\n\r", gold);
+	SPRINTF(buf, "Bingo! You got %d gold coins.\n\r", gold);
 	send_to_char(buf, ch);
 	if (IS_PC(ch) && IS_PC(victim))
 	  GET_ALIGNMENT(ch)-=20;
@@ -561,7 +561,7 @@ void do_steal(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   
   if (ohoh && IS_NPC(victim) && AWAKE(victim)) {
     if (IS_SET(victim->specials.act, ACT_NICE_THIEF)) {
-      sprintf(buf, "%s is a bloody thief.", GET_NAME(ch));
+      SPRINTF(buf, "%s is a bloody thief.", GET_NAME(ch));
       do_shout(victim, buf, 0);
       do_say(victim, "Don't you ever do that again!", 0);
     } else {
@@ -607,7 +607,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
 	send_to_char("You have the following intrinsic spell abilities:\n\r",ch);
 	for(i=0; *spells[i] != '\n' && i < (MAX_EXIST_SPELL+1); i++)
 	  if(IsIntrinsic(ch,i+1)) {
-	    sprintf(buf,"%-30s %s \n\r",spells[i],
+	    SPRINTF(buf,"%-30s %s \n\r",spells[i],
 		    how_good(ch->skills[i+1].learned));
 	    if (strlen(buf)+strlen(buffer) > (MAX_STRING_LENGTH*2)-2)
 	      break;
@@ -621,7 +621,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
 	for(i=0; *spells[i] != '\n'; i++)
 	  if (skill_info[i+1].spell_pointer && (ch->skills[i+1].learned ||
 						IsIntrinsic(ch, i+1))) {
-	    sprintf(buf,"[%-3d] %-25s %s",
+	    SPRINTF(buf,"[%-3d] %-25s %s",
 		    (skill_info[i+1].min_level[MIN_LEVEL_MAGIC] < 
 		     skill_info[i+1].min_level[MIN_LEVEL_CLERIC] ? 
 		     skill_info[i+1].min_level[MIN_LEVEL_MAGIC] : 
@@ -646,7 +646,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
         if (!skill_info[i+1].spell_pointer && 
 	    ( IS_SET(ch->player.class, skill_info[i+1].class_use) ||
 	     IsIntrinsic(ch,i+1))) {
-          sprintf(buf,"%-30s %s \n\r",spells[i],
+          SPRINTF(buf,"%-30s %s \n\r",spells[i],
                   how_good(ch->skills[i+1].learned));
           if (strlen(buf)+strlen(buffer) > (MAX_STRING_LENGTH*2)-2)
             break;
@@ -669,7 +669,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
       send_to_char("You have knowledge of these skills:\n\r", ch);
       for(i=0; *spells[i] != '\n' && i < (MAX_EXIST_SPELL+1); i++)
 	if (!skill_info[i+1].spell_pointer && ch->skills[i+1].learned) {
-	  sprintf(buf,"%-30s %s \n\r",spells[i],
+	  SPRINTF(buf,"%-30s %s \n\r",spells[i],
 		  how_good(ch->skills[i+1].learned));
 	  if (strlen(buf)+strlen(buffer) > (MAX_STRING_LENGTH*2)-2)
 	    break;
@@ -690,7 +690,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
       send_to_char("You have knowledge of these skills:\n\r", ch);
       for(i=0; *spells[i] != '\n' && i < (MAX_EXIST_SPELL+1); i++)
 	if (!skill_info[i+1].spell_pointer && ch->skills[i+1].learned) {
-	  sprintf(buf,"%-30s %s \n\r",spells[i],
+	  SPRINTF(buf,"%-30s %s \n\r",spells[i],
 		  how_good(ch->skills[i+1].learned));
 	  if (strlen(buf)+strlen(buffer) > (MAX_STRING_LENGTH*2)-2)
 	    break;
@@ -712,7 +712,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
 	if (skill_info[i+1].spell_pointer &&
 	    (skill_info[i+1].min_level[MIN_LEVEL_MAGIC] <=
 	     GET_LEVEL(ch,MAGE_LEVEL_IND))) {
-	  sprintf(buf,"[%d] %s %s \n\r",
+	  SPRINTF(buf,"[%d] %s %s \n\r",
                   skill_info[i+1].min_level[MIN_LEVEL_MAGIC],
 		  spells[i],how_good(ch->skills[i+1].learned));
 	  if (strlen(buf)+strlen(buffer) > (MAX_STRING_LENGTH*2)-2)
@@ -738,7 +738,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
 	if (skill_info[i+1].spell_pointer &&
 	    (skill_info[i+1].min_level[MIN_LEVEL_CLERIC] <=
 	     GET_LEVEL(ch,CLERIC_LEVEL_IND))){
-	  sprintf(buf,"[%d] %s %s \n\r",
+	  SPRINTF(buf,"[%d] %s %s \n\r",
                   skill_info[i+1].min_level[MIN_LEVEL_CLERIC],
 		  spells[i],how_good(ch->skills[i+1].learned));
 	  if (strlen(buf)+strlen(buffer) > (MAX_STRING_LENGTH*2)-2)
@@ -763,7 +763,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
 	if (skill_info[i+1].spell_pointer &&
 	    (skill_info[i+1].min_level[MIN_LEVEL_DRUID] <=
 	     GET_LEVEL(ch, DRUID_LEVEL_IND))){
-	  sprintf(buf,"[%d] %s %s \n\r",
+	  SPRINTF(buf,"[%d] %s %s \n\r",
 		  skill_info[i+1].min_level[MIN_LEVEL_DRUID],
 		  spells[i],how_good(ch->skills[i+1].learned));
 	  if (strlen(buf)+strlen(buffer) > MAX_STRING_LENGTH-2)
@@ -785,7 +785,7 @@ void do_practice(struct char_data *ch, char *arg, int cmd)
     send_to_char("You have knowledge of these skills:\n\r", ch);
     for(i=0; *spells[i] != '\n' && i < (MAX_EXIST_SPELL+1); i++)
       if (!skill_info[i+1].spell_pointer && ch->skills[i+1].learned) {
-	sprintf(buf,"%-30s %s \n\r",spells[i],
+	SPRINTF(buf,"%-30s %s \n\r",spells[i],
 		how_good(ch->skills[i+1].learned));
 	if (strlen(buf)+strlen(buffer) > (MAX_STRING_LENGTH*2)-2)
 	  break;
@@ -828,7 +828,7 @@ void do_idea(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     return;
   }
   
-  sprintf(str, "**%s: %s\n", GET_NAME(ch), argument);
+  SPRINTF(str, "**%s: %s\n", GET_NAME(ch), argument);
   
   fputs(str, fl);
   fclose(fl);
@@ -857,7 +857,7 @@ void do_typo(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     return;
   }
   
-  sprintf(str, "**%s[%d]: %s\n",
+  SPRINTF(str, "**%s[%d]: %s\n",
 	  GET_NAME(ch), ch->in_room, argument);
   fputs(str, fl);
   fclose(fl);
@@ -887,7 +887,7 @@ void do_bug(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     return;
   }
   
-  sprintf(str, "**%s[%d]: %s\n",
+  SPRINTF(str, "**%s[%d]: %s\n",
 	  GET_NAME(ch), ch->in_room, argument);
   fputs(str, fl);
   fclose(fl);
@@ -991,7 +991,7 @@ void do_group(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	k = ch;
       
       if (IS_AFFECTED(k, AFF_GROUP)) {
-	sprintf(buf, "     $N (Head of group) HP:%s MV:%s",
+	SPRINTF(buf, "     $N (Head of group) HP:%s MV:%s",
 		Condition(k), Tiredness(k));
 	act(buf,FALSE,ch, 0, k, TO_CHAR);
 	
@@ -999,7 +999,7 @@ void do_group(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       
       for(f=k->followers; f; f=f->next)
 	if (IS_AFFECTED(f->follower, AFF_GROUP)) {
-	  sprintf(buf, "     $N  \tHP:%s MV:%s",
+	  SPRINTF(buf, "     $N  \tHP:%s MV:%s",
 		  Condition(f->follower), Tiredness(f->follower));
 	  act(buf,FALSE,ch, 0, f->follower, TO_CHAR);
 	}
@@ -1279,7 +1279,7 @@ void do_use(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     char_from_room(f);
     char_to_room(f, 3);
     obj_to_char(f->link, ch);
-    sprintf(buf, "You now have %s.\n", f->link->short_description);
+    SPRINTF(buf, "You now have %s.\n", f->link->short_description);
     send_to_char(buf, ch);
     return;
   }
@@ -1371,7 +1371,7 @@ void do_use(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     
     
     if(number(1,26) == 20) { /* One in 20 chance of it destroying itself */
-      sprintf(buf, "%s shudders and shakes, finally cracking into a million pieces.\n", stick->short_description);
+      SPRINTF(buf, "%s shudders and shakes, finally cracking into a million pieces.\n", stick->short_description);
       send_to_char(buf, ch);
       stick = unequip_char(ch, HOLD);
       char_from_room(stick->link);
@@ -1384,7 +1384,7 @@ void do_use(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
     stick = unequip_char(ch, HOLD);
     act("$p starts to shudder an shake in $n's hands.", FALSE, ch, stick, 0, TO_ROOM);
-    sprintf(buf, "%s shakes in your hands and grows into %s.\n", stick->short_description, stick->link->player.short_descr);
+    SPRINTF(buf, "%s shakes in your hands and grows into %s.\n", stick->short_description, stick->link->player.short_descr);
     send_to_char(buf, ch);
     SET_BIT(stick->link->specials.affected_by, AFF_CHARM);
     char_from_room(stick->link);
@@ -1463,7 +1463,7 @@ void do_alias(struct char_data *ch, char *arg, int cmd)
       if (ch->specials.A_list) {
 	for(i=0;i<10;i++) {
 	  if (ch->specials.A_list->com[i]) {
-	    sprintf(buf,"[%d] %s\n\r",i, ch->specials.A_list->com[i]);
+	    SPRINTF(buf,"[%d] %s\n\r",i, ch->specials.A_list->com[i]);
 	    send_to_char(buf,ch);
 	  }
 	}
@@ -1533,7 +1533,7 @@ void do_alias(struct char_data *ch, char *arg, int cmd)
       if (GET_ALIAS(ch, num)) {
 	strcpy(buf, GET_ALIAS(ch, num));
 	if (*arg) {
-	  sprintf(buf2,"%s%s",buf,arg);
+	  SPRINTF(buf2,"%s%s",buf,arg);
 	  command_interpreter(ch, buf2);
 	} else {
 	  command_interpreter(ch, buf);
@@ -1706,14 +1706,14 @@ void do_split(struct char_data *ch, char *arg, int UNUSED(cmd)) {
       if (k->in_room == ch->in_room) {
 	GET_GOLD(k) += share;
 	num -= share;
-	sprintf(buf, "$N gives you %d gold", share);
+	SPRINTF(buf, "$N gives you %d gold", share);
 	act(buf, 0, k, 0, ch, TO_CHAR);
       }
     } else {
       k = ch;
       GET_GOLD(k) += share;
       num -= share;
-      sprintf(buf, "You keep %d gold\n\r", share);
+      SPRINTF(buf, "You keep %d gold\n\r", share);
       send_to_char(buf, ch);
     }
     
@@ -1721,12 +1721,12 @@ void do_split(struct char_data *ch, char *arg, int UNUSED(cmd)) {
       if (IS_AFFECTED(f->follower, AFF_GROUP)) {
 	if (f->follower->in_room == ch->in_room) {
 	  if (f->follower != ch) {
-	    sprintf(buf, "$N gives you %d gold", share);
+	    SPRINTF(buf, "$N gives you %d gold", share);
 	    act(buf, 0, f->follower, 0, ch, TO_CHAR);
-	    sprintf(buf, "You give $N %d gold", share);
+	    SPRINTF(buf, "You give $N %d gold", share);
 	    act(buf, 0, ch, 0, f->follower, TO_CHAR);
 	  } else {
-	    sprintf(buf, "You keep %d gold\n\r", share);
+	    SPRINTF(buf, "You keep %d gold\n\r", share);
 	    send_to_char(buf, ch);	  
 	  }
 	  GET_GOLD(f->follower) += share;
@@ -1736,7 +1736,7 @@ void do_split(struct char_data *ch, char *arg, int UNUSED(cmd)) {
     
     /* give rest to ch */
     GET_GOLD(ch) += num;
-    sprintf(buf, "And you keep the %d gold left over.\n\r", num);
+    SPRINTF(buf, "And you keep the %d gold left over.\n\r", num);
     send_to_char(buf, ch);	  
     
     
@@ -1817,20 +1817,20 @@ void do_donate(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
   }
   if (count > 1) {
-    sprintf(buf, "You donate %s (%d).\n\r", arg, count);
+    SPRINTF(buf, "You donate %s (%d).\n\r", arg, count);
     act(buf, 1, ch, 0, 0, TO_CHAR);
-    sprintf(buf, "$n donates %s.\n\r", arg);
+    SPRINTF(buf, "$n donates %s.\n\r", arg);
     act(buf, 1, ch, 0, 0, TO_ROOM);
-    sprintf(buf, "%s has just donated %s.\n\r", GET_NAME(ch), arg);
+    SPRINTF(buf, "%s has just donated %s.\n\r", GET_NAME(ch), arg);
     send_to_room(buf, 99);
     act("Thank you for your most generous donation.",
         FALSE, ch, 0, 0, TO_CHAR);
   } else if (count == 1) {
-    sprintf(buf, "You donate %s \n\r", arg);
+    SPRINTF(buf, "You donate %s \n\r", arg);
     act(buf, 1, ch, 0, 0, TO_CHAR);
-    sprintf(buf, "$n donates %s.\n\r", arg);
+    SPRINTF(buf, "$n donates %s.\n\r", arg);
     act(buf, 1, ch, 0, 0, TO_ROOM);
-    sprintf(buf, "%s has just donated %s.\n\r", GET_NAME(ch), arg);
+    SPRINTF(buf, "%s has just donated %s.\n\r", GET_NAME(ch), arg);
     send_to_room(buf, 99);
     act("Thank you for your most generous donation.",
         FALSE, ch, 0, 0, TO_CHAR);

--- a/src/act.social.c
+++ b/src/act.social.c
@@ -225,7 +225,7 @@ void do_insult(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 			send_to_char("Can't hear you!\n\r", ch);
 		} else {
 			if(victim != ch) { 
-				sprintf(buf, "You insult %s.\n\r",GET_NAME(victim) );
+				SPRINTF(buf, "You insult %s.\n\r",GET_NAME(victim) );
 				send_to_char(buf,ch);
 
 				switch(random()%3) {

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -84,20 +84,20 @@ void do_auth(struct char_data *ch, char *argument, int cmd)
     one_argument(argument, word);
     if (str_cmp(word,"yes")==0) {
       d->character->generic = NEWBIE_START;
-      sprintf(buf2,"%s has just accepted %s into the game.",
+      SPRINTF(buf2,"%s has just accepted %s into the game.",
 	      ch->player.name,name);
       log_msg(buf2);
       SEND_TO_Q("You have been accepted.  Press enter\n\r", d);
     } else if (str_cmp(word,"no")==0){
       SEND_TO_Q("You have been denied.  Press enter\n\r", d);
-      sprintf(buf2,"%s has just denied %s from the game.",
+      SPRINTF(buf2,"%s has just denied %s from the game.",
               ch->player.name,name);
       log_msg(buf2);
       d->character->generic = NEWBIE_AXE;
     } else {
       SEND_TO_Q(argument, d);
       SEND_TO_Q("\n\r", d);
-      sprintf(buf, "You send '%s'\n\r", argument);
+      SPRINTF(buf, "You send '%s'\n\r", argument);
       send_to_char(buf, ch);
       return;
     }
@@ -208,7 +208,7 @@ void do_setsev(struct char_data *ch, char *arg, int UNUSED(cmd)) {
       return;
     }
     ch->specials.sev = sev;
-    sprintf(buf2,"Your severety level have been set to %d.\n\r",ch->specials.sev);
+    SPRINTF(buf2,"Your severety level have been set to %d.\n\r",ch->specials.sev);
     send_to_char(buf2,ch);
     return;
   } else {
@@ -274,7 +274,7 @@ void do_bamfin(struct char_data *ch, char *arg, int UNUSED(cmd)) {
  if(len > 150) {
    send_to_char("String too long.  Truncated to:\n\r", ch);
    arg[150] = '\0';
-   sprintf(buf, "%s\n\r", arg);
+   SPRINTF(buf, "%s\n\r", arg);
    send_to_char(buf, ch);   
    len = 150;
  }
@@ -323,7 +323,7 @@ void do_bamfout(struct char_data *ch, char *arg, int UNUSED(cmd)) {
  if(len > 150) {
    send_to_char("String too long.  Truncated to:\n\r", ch);
    arg[150] = '\0';
-   sprintf(buf, "%s\n\r", arg);
+   SPRINTF(buf, "%s\n\r", arg);
    send_to_char(buf, ch);
    len = 150;
  }
@@ -468,7 +468,7 @@ void do_highfive(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     if ((tch = get_char_room_vis(ch,buf)) != 0) {
       if ((GetMaxLevel(tch) >= DEMIGOD) && (!IS_NPC(tch)) && 
 	  (GetMaxLevel(ch)  >= DEMIGOD) && (!IS_NPC(ch))) {
-       sprintf(mess, "Time stops for a moment as %s and %s high five.\n\r",
+       SPRINTF(mess, "Time stops for a moment as %s and %s high five.\n\r",
 	    ch->player.name, tch->player.name);
        send_to_all(mess);
       } else {
@@ -477,7 +477,7 @@ void do_highfive(struct char_data *ch, char *argument, int UNUSED(cmd)) {
        act("$n and $N do a high five.", TRUE, ch, 0, tch, TO_NOTVICT);
       }
     } else {
-      sprintf(buf,"I don't see anyone here like that.\n\r");
+      SPRINTF(buf,"I don't see anyone here like that.\n\r");
       send_to_char(buf,ch);
     }
   }
@@ -507,12 +507,12 @@ void do_silence(struct char_data *ch, char * UNUSED(argument),
   if (Silence == 0) {
     Silence = 1;
     send_to_char("You have now silenced polyed mobles.\n\r",ch);
-    sprintf(buf,"%s has stopped Polymophed characters from shouting.",ch->player.name);
+    SPRINTF(buf,"%s has stopped Polymophed characters from shouting.",ch->player.name);
     log_msg(buf);
   } else {
     Silence = 0;
     send_to_char("You have now unsilenced mobles.\n\r",ch);
-    sprintf(buf,"%s has allowed Polymophed characters to shout.",ch->player.name);
+    SPRINTF(buf,"%s has allowed Polymophed characters to shout.",ch->player.name);
     log_msg(buf);
   }
 }
@@ -594,7 +594,7 @@ void do_wizlock(struct char_data *ch, char * UNUSED(argument),
          }
       }
       strcpy(hostlist[numberhosts],buf);
-      sprintf(buf,"%s has added host %s to the access denied list.",
+      SPRINTF(buf,"%s has added host %s to the access denied list.",
 	      GET_NAME(ch),hostlist[numberhosts]);
       log_msg(buf);
       numberhosts++;
@@ -631,7 +631,7 @@ void do_wizlock(struct char_data *ch, char * UNUSED(argument),
          if (strncmp(hostlist[a],buf,length) == 0) {
 	    for( b = a ; b <= numberhosts ; b++) 
 	      strcpy(hostlist[b],hostlist[b+1]);
- 	    sprintf(buf,"%s has removed host %s from the access denied list.",
+ 	    SPRINTF(buf,"%s has removed host %s from the access denied list.",
 		    GET_NAME(ch),hostlist[numberhosts]);
 	    log_msg(buf);
 	    numberhosts--;
@@ -648,7 +648,7 @@ void do_wizlock(struct char_data *ch, char * UNUSED(argument),
          return;
       }
       for( a = 0 ; a <= numberhosts-1 ; a++) {
-         sprintf(buf,"Host: %s\n",hostlist[a]);
+         SPRINTF(buf,"Host: %s\n",hostlist[a]);
          send_to_char(buf, ch);
       }
       return;
@@ -710,7 +710,7 @@ void do_rsave(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     sscanf(argument,"%d %d", &start, &end);
       
     if ((start <= end) && (start != -1) && (end != -2)) {
-      sprintf(buf,"mv rooms/%s rooms/%s.bak", GET_NAME(ch), GET_NAME(ch));
+      SPRINTF(buf,"mv rooms/%s rooms/%s.bak", GET_NAME(ch), GET_NAME(ch));
       system(buf);
       RoomSave(ch,start,end);
     }
@@ -730,7 +730,7 @@ void do_emote(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	if (!*(argument + i))
 		send_to_char("Yes.. But what?\n\r", ch);
 	else	{
-		sprintf(buf,"$n %s", argument + i);
+		SPRINTF(buf,"$n %s", argument + i);
 		act(buf,FALSE,ch,0,0,TO_ROOM);
 		send_to_char("Ok.\n\r", ch);
 	}
@@ -755,7 +755,7 @@ void do_echo(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	  }
 	} else	{
 	  if (IS_IMMORTAL(ch)) {
-		sprintf(buf,"%s\n\r", argument + i);
+		SPRINTF(buf,"%s\n\r", argument + i);
 		send_to_room_except(buf, ch->in_room, ch);
 		send_to_char("Ok.\n\r", ch);
 	      }
@@ -774,7 +774,7 @@ void do_system(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	if (!*(argument + i))
 		send_to_char("That must be a mistake...\n\r", ch);
 	else	{
-		sprintf(buf,"\n\r%s\n\r", argument + i);
+		SPRINTF(buf,"\n\r%s\n\r", argument + i);
                 send_to_all(buf);
 	}
 }
@@ -1062,12 +1062,12 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     /* stats on room */
     if (!str_cmp("room", arg1)) {
       rm = real_roomp(ch->in_room);
-      sprintf(buf, "Room name: %s, Of zone : %d. V-Number : %d, R-number : %d\n\r",
+      SPRINTF(buf, "Room name: %s, Of zone : %d. V-Number : %d, R-number : %d\n\r",
 	      rm->name, rm->zone, rm->number, ch->in_room);
       send_to_char(buf, ch);
       
       sprinttype(rm->sector_type,sector_types,buf2);
-      sprintf(buf, "Sector type : %s ", buf2);
+      SPRINTF(buf, "Sector type : %s ", buf2);
       send_to_char(buf, ch);
       
       strcpy(buf,"Special procedure : ");
@@ -1118,11 +1118,11 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       for (i = 0; i <= 5; i++) {
 	if (rm->dir_option[i]) {
 	  if (rm->dir_option[i]->keyword) {
-	    sprintf(buf,"Direction %s . Keyword : %s\n\r",
+	    SPRINTF(buf,"Direction %s . Keyword : %s\n\r",
 		    dirs[i], rm->dir_option[i]->keyword);
 	    send_to_char(buf, ch);
 	  } else {
-	    sprintf(buf,"Direction %s \n\r",   dirs[i]);
+	    SPRINTF(buf,"Direction %s \n\r",   dirs[i]);
 	    send_to_char(buf, ch);
 	  }
 	  strcpy(buf, "Description:\n\r  ");
@@ -1132,7 +1132,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	    strcat(buf,"UNDEFINED\n\r");
 	  send_to_char(buf, ch);
 	  sprintbit((unsigned) rm->dir_option[i]->exit_info,exit_bits,buf2);
-	  sprintf(buf, "Exit flag: %s \n\rKey no: %d\n\rTo room (R-Number): %d\n\r",
+	  SPRINTF(buf, "Exit flag: %s \n\rKey no: %d\n\rTo room (R-Number): %d\n\r",
 		  buf2, rm->dir_option[i]->key,
 		  rm->dir_option[i]->to_room);
 	  send_to_char(buf, ch);
@@ -1163,13 +1163,13 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	break;
       }
       
-      sprintf(buf2, " %s - Name : %s [R-Number%d], In room [%d]\n\r",
+      SPRINTF(buf2, " %s - Name : %s [R-Number%d], In room [%d]\n\r",
 	      (!IS_NPC(k) ? "PC" : (!IS_MOB(k) ? "NPC" : "MOB")),
 	      GET_NAME(k), k->nr, k->in_room);
       strcat(buf, buf2);
       send_to_char(buf, ch);
       if (IS_MOB(k)) {
-	sprintf(buf, "V-Number [%d]\n\r", mob_index[k->nr].virtual);
+	SPRINTF(buf, "V-Number [%d]\n\r", mob_index[k->nr].virtual);
 	send_to_char(buf, ch);
       }
       
@@ -1199,7 +1199,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       }
       strcat(buf, buf2);
       
-      sprintf(buf2,"   Level [%d/%d/%d/%d/%d/%d/%d] Alignment[%d]\n\r",
+      SPRINTF(buf2,"   Level [%d/%d/%d/%d/%d/%d/%d] Alignment[%d]\n\r",
 	      k->player.level[0], k->player.level[1], 
 	      k->player.level[2], k->player.level[3], 
 	      k->player.level[4], k->player.level[5],
@@ -1208,7 +1208,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       strcat(buf, buf2);
       send_to_char(buf, ch);
       
-      sprintf(buf,"Birth : [%ld]secs, Logon[%ld]secs, Played[%d]secs\n\r", 
+      SPRINTF(buf,"Birth : [%ld]secs, Logon[%ld]secs, Played[%d]secs\n\r", 
 	      k->player.time.birth,
 	      k->player.time.logon,
 	      k->player.time.played);
@@ -1217,14 +1217,14 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 
       age2(k, &ma);
       
-      sprintf(buf,"Age: [%d] Y, [%d] M, [%d] D, [%d] H. ",
+      SPRINTF(buf,"Age: [%d] Y, [%d] M, [%d] D, [%d] H. ",
 	      ma.year, ma.month, ma.day, ma.hours);
       send_to_char(buf,ch);
       
-      sprintf(buf," Height [%d]cm, Wgt [%d]pounds \n\r", GET_HEIGHT(k), GET_WEIGHT(k));
+      SPRINTF(buf," Height [%d]cm, Wgt [%d]pounds \n\r", GET_HEIGHT(k), GET_WEIGHT(k));
       send_to_char(buf,ch);
       
-      sprintf(buf,"Str:[%d/%d] Int:[%d] Ws:[%d] Dex:[%d] Con:[%d] Ch:[%d], Ego: [%d]\n\r",
+      SPRINTF(buf,"Str:[%d/%d] Int:[%d] Ws:[%d] Dex:[%d] Con:[%d] Ch:[%d], Ego: [%d]\n\r",
 	      GET_STR(k), GET_ADD(k),
 	      GET_INT(k),
 	      GET_WIS(k),
@@ -1234,13 +1234,13 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	      GET_EGO(k));
       send_to_char(buf,ch);
       
-      sprintf(buf,"Mana:[%d/%d+%d] Hit:[%d/%d] Move:[%d/%d+%d]\n\r",
+      SPRINTF(buf,"Mana:[%d/%d+%d] Hit:[%d/%d] Move:[%d/%d+%d]\n\r",
 	      GET_MANA(k),mana_limit(k),mana_gain(k),
 	      GET_HIT(k),hit_limit(k),
 	      GET_MOVE(k),move_limit(k),move_gain(k) );
       send_to_char(buf,ch);
       
-      sprintf(buf,"AC:[%d/10], Coins: [%d], Exp: [%d], Hitroll: [%d], Damroll: [%d] sf[%d]\n\r",
+      SPRINTF(buf,"AC:[%d/10], Coins: [%d], Exp: [%d], Hitroll: [%d], Damroll: [%d] sf[%d]\n\r",
 	      GET_AC(k),
 	      GET_GOLD(k),
 	      GET_EXP(k),
@@ -1250,7 +1250,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       send_to_char(buf,ch);
       
       sprinttype(GET_POS(k),position_types,buf2);
-      sprintf(buf,"Position: %s, Fighting: %s",buf2,
+      SPRINTF(buf,"Position: %s, Fighting: %s",buf2,
 	      ((k->specials.fighting) ? GET_NAME(k->specials.fighting) : "Nobody") );
       if (k->desc) {
 	sprinttype(k->desc->connected,connected_types,buf2);
@@ -1273,7 +1273,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       
       strcat(buf, buf2);
       
-      sprintf(buf2,",Timer [%d] \n\r", k->specials.timer);
+      SPRINTF(buf2,",Timer [%d] \n\r", k->specials.timer);
       strcat(buf, buf2);
       send_to_char(buf, ch);
       
@@ -1284,22 +1284,22 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       }
       
       if (IS_NPC(k)) {
-	sprintf(buf, " NPC Bare Hand Damage %dd%d.\n\r",
+	SPRINTF(buf, " NPC Bare Hand Damage %dd%d.\n\r",
 		k->specials.damnodice, k->specials.damsizedice);
 	send_to_char(buf, ch);
       }
       
-      sprintf(buf,"Carried weight: %d   Carried items: %d ",
+      SPRINTF(buf,"Carried weight: %d   Carried items: %d ",
 	      IS_CARRYING_W(k),
 	      IS_CARRYING_N(k) );
 
       for(i=0,i2=0;i<MAX_WEAR;i++)
 	if (k->equipment[i]) i2++;
-      sprintf(buf2,"Items in equipment: %d\n\r", i2);
+      SPRINTF(buf2,"Items in equipment: %d\n\r", i2);
       strcat(buf,buf2);
       send_to_char(buf, ch);
       
-      sprintf(buf,"Apply saving throws: [%d] [%d] [%d] [%d] [%d], ",
+      SPRINTF(buf,"Apply saving throws: [%d] [%d] [%d] [%d] [%d], ",
 	      k->specials.apply_saving_throw[0],
 	      k->specials.apply_saving_throw[1],
 	      k->specials.apply_saving_throw[2],
@@ -1307,13 +1307,13 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	      k->specials.apply_saving_throw[4]);
       send_to_char(buf, ch);
       
-      sprintf(buf, "Thirst: %d, Hunger: %d, Drunk: %d\n\r",
+      SPRINTF(buf, "Thirst: %d, Hunger: %d, Drunk: %d\n\r",
 	      k->specials.conditions[THIRST],
 	      k->specials.conditions[FULL],
 	      k->specials.conditions[DRUNK]);
       send_to_char(buf, ch);
       
-      sprintf(buf, "Master is '%s'    ",
+      SPRINTF(buf, "Master is '%s'    ",
 	      ((k->master) ? GET_NAME(k->master) : "NOBODY"));
       send_to_char(buf, ch);
       send_to_char("Followers are:\n\r", ch);
@@ -1339,7 +1339,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       send_to_char("Race: ",ch);
       sprinttype((k->race),RaceName,buf2);
       send_to_char(buf2, ch);
-      sprintf(buf, "  Generic pointer: %d\n\r", (int)k->generic);
+      SPRINTF(buf, "  Generic pointer: %d\n\r", (int)k->generic);
       send_to_char(buf, ch);
       
       /* Showing the bitvector */
@@ -1358,23 +1358,23 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	  /* This is somewhat of a hack in order to  */
           if(aff->location == APPLY_IMMUNE && !(aff->modifier) &&
              aff->bitvector) {
-            sprintf(buf, "Spell : '%s'\n\r",spells[aff->type-1]);
-            sprintf(buf,"     Modifies %s by %ld points\n\r",
+            SPRINTF(buf, "Spell : '%s'\n\r",spells[aff->type-1]);
+            SPRINTF(buf,"     Modifies %s by %ld points\n\r",
                     apply_types[(int)aff->location],aff->bitvector);
             send_to_char(buf,ch);
-            sprintf(buf,"     Expires in %3d hours, Resistance Bits set ",
+            SPRINTF(buf,"     Expires in %3d hours, Resistance Bits set ",
                     aff->duration);
             send_to_char(buf, ch);
             sprintbit((unsigned)aff->bitvector,immunity_names,buf);
             strcat(buf,"\n\r");
             send_to_char(buf, ch);
           } else {
-	    sprintf(buf, "Spell : '%s'\n\r",spells[aff->type-1]);
+	    SPRINTF(buf, "Spell : '%s'\n\r",spells[aff->type-1]);
 	    send_to_char(buf, ch);
-	    sprintf(buf,"     Modifies %s by %d points\n\r",
+	    SPRINTF(buf,"     Modifies %s by %d points\n\r",
 		    apply_types[(int)aff->location], aff->modifier);
 	    send_to_char(buf, ch);
-	    sprintf(buf,"     Expires in %3d hours, Bits set ",
+	    SPRINTF(buf,"     Expires in %3d hours, Bits set ",
 		    aff->duration);
 	    send_to_char(buf, ch);
 	    if (aff->location != APPLY_BV2)
@@ -1391,12 +1391,12 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     /* stat on object */
     if ((j=(struct obj_data *)get_obj_vis_world(ch, arg1, &count)) != NULL) {
       virtual = (j->item_number >= 0) ? obj_index[j->item_number].virtual : 0;
-      sprintf(buf, "Object name: [%s], R-number: [%d], V-number: [%d] Item type: ",
+      SPRINTF(buf, "Object name: [%s], R-number: [%d], V-number: [%d] Item type: ",
 	      j->name, j->item_number, virtual);
       sprinttype(GET_ITEM_TYPE(j),item_types,buf2);
       strcat(buf,buf2); strcat(buf,"\n\r");
       send_to_char(buf, ch);
-      sprintf(buf, "Short description: %s\n\rLong description:\n\r%s\n\r",
+      SPRINTF(buf, "Short description: %s\n\rLong description:\n\r%s\n\r",
 	      ((j->short_description) ? j->short_description : "None"),
 	      ((j->description) ? j->description : "None") );
       send_to_char(buf, ch);
@@ -1428,7 +1428,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       strcat(buf,"\n\r");
       send_to_char(buf,ch);
       
-      sprintf(buf,"Weight: %d, Value: %d, Cost/day: %d, Timer: %d, Ego: %d\n\r",
+      SPRINTF(buf,"Weight: %d, Value: %d, Cost/day: %d, Timer: %d, Ego: %d\n\r",
 	      j->obj_flags.weight,j->obj_flags.cost,
 	      j->obj_flags.cost_per_day,  j->obj_flags.timer, 
 	      GET_OBJ_EGO(j));
@@ -1438,7 +1438,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       if (j->in_room == NOWHERE)
 	strcat(buf,"Nowhere");
       else {
-	sprintf(buf2,"%d",j->in_room);
+	SPRINTF(buf2,"%d",j->in_room);
 	strcat(buf,buf2);
       }
       strcat(buf," ,In object: ");
@@ -1446,13 +1446,13 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       
       switch (j->obj_flags.type_flag) {
       case ITEM_LIGHT : 
-	sprintf(buf, "Colour : [%d]\n\rType : [%d]\n\rHours : [%d]",
+	SPRINTF(buf, "Colour : [%d]\n\rType : [%d]\n\rHours : [%d]",
 		j->obj_flags.value[0],
 		j->obj_flags.value[1],
 		j->obj_flags.value[2]);
 	break;
       case ITEM_SCROLL : 
-	sprintf(buf, "Spells : %d, %d, %d, %d",
+	SPRINTF(buf, "Spells : %d, %d, %d, %d",
 		j->obj_flags.value[0],
 		j->obj_flags.value[1],
 		j->obj_flags.value[2],
@@ -1460,80 +1460,80 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	break;
       case ITEM_WAND :
       case ITEM_STAFF:
-	sprintf(buf, "Level: %d Spell : %d\n\rCharges : %d",
+	SPRINTF(buf, "Level: %d Spell : %d\n\rCharges : %d",
 		j->obj_flags.value[0],
 		j->obj_flags.value[3],
 		j->obj_flags.value[2]);
 	break;
       case ITEM_WEAPON :
-	sprintf(buf, "Tohit : %d\n\rTodam : %dD%d\n\rType : %d",
+	SPRINTF(buf, "Tohit : %d\n\rTodam : %dD%d\n\rType : %d",
 		j->obj_flags.value[0],
 		j->obj_flags.value[1],
 		j->obj_flags.value[2],
 		j->obj_flags.value[3]);
 	break;
       case ITEM_FIREWEAPON : 
-	sprintf(buf, "Tohit: %d\n\rDam: %d\n\rType: %d Min Weight: %d\n\r",
+	SPRINTF(buf, "Tohit: %d\n\rDam: %d\n\rType: %d Min Weight: %d\n\r",
 		j->obj_flags.value[2],
 		j->obj_flags.value[3],
 		j->obj_flags.value[0],
 		j->obj_flags.value[1]);
 	break;
       case ITEM_MISSILE : 
-	sprintf(buf, "Tohit : %d\n\rTodam : %d\n\rType : %d",
+	SPRINTF(buf, "Tohit : %d\n\rTodam : %d\n\rType : %d",
 		j->obj_flags.value[0],
 		j->obj_flags.value[1],
 		j->obj_flags.value[3]);
 	break;
       case ITEM_ARMOR :
-	sprintf(buf, "AC-apply : [%d]\n\rFull Strength : [%d]",
+	SPRINTF(buf, "AC-apply : [%d]\n\rFull Strength : [%d]",
 		j->obj_flags.value[0],
 		j->obj_flags.value[1]);
 	
 	break;
       case ITEM_POTION : 
-	sprintf(buf, "Spells : %d, %d, %d, %d",
+	SPRINTF(buf, "Spells : %d, %d, %d, %d",
 		j->obj_flags.value[0],
 		j->obj_flags.value[1],
 		j->obj_flags.value[2],
 		j->obj_flags.value[3]); 
 	break;
       case ITEM_TRAP :
-	sprintf(buf, "level: %d, att type: %d, damage class: %d, charges: %d", 
+	SPRINTF(buf, "level: %d, att type: %d, damage class: %d, charges: %d", 
 		j->obj_flags.value[0],
 		j->obj_flags.value[1],
 		j->obj_flags.value[2],
 		j->obj_flags.value[3]);
 	break;
       case ITEM_CONTAINER :
-	sprintf(buf, "Max-contains : %d\n\rLocktype : %d\n\rCorpse : %s",
+	SPRINTF(buf, "Max-contains : %d\n\rLocktype : %d\n\rCorpse : %s",
 		j->obj_flags.value[0],
 		j->obj_flags.value[1],
 		j->obj_flags.value[3]?"Yes":"No");
 	break;
       case ITEM_DRINKCON :
 	sprinttype(j->obj_flags.value[2],drinks,buf2);
-	sprintf(buf, "Max-contains : %d\n\rContains : %d\n\rPoisoned : %d\n\rLiquid : %s",
+	SPRINTF(buf, "Max-contains : %d\n\rContains : %d\n\rPoisoned : %d\n\rLiquid : %s",
 		j->obj_flags.value[0],
 		j->obj_flags.value[1],
 		j->obj_flags.value[3],
 		buf2);
 	break;
       case ITEM_NOTE :
-	sprintf(buf, "Tounge : %d",
+	SPRINTF(buf, "Tounge : %d",
 		j->obj_flags.value[0]);
 	break;
       case ITEM_KEY :
-	sprintf(buf, "Keytype : %d",
+	SPRINTF(buf, "Keytype : %d",
 		j->obj_flags.value[0]);
 	break;
       case ITEM_FOOD :
-	sprintf(buf, "Makes full : %d\n\rPoisoned : %d",
+	SPRINTF(buf, "Makes full : %d\n\rPoisoned : %d",
 		j->obj_flags.value[0],
 		j->obj_flags.value[3]);
 	break;
 	default :
-	  sprintf(buf,"Values 0-3 : [%d] [%d] [%d] [%d]",
+	  SPRINTF(buf,"Values 0-3 : [%d] [%d] [%d] [%d]",
 		  j->obj_flags.value[0],
 		  j->obj_flags.value[1],
 		  j->obj_flags.value[2],
@@ -1580,7 +1580,7 @@ void do_stat(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       send_to_char("Can affect char :\n\r", ch);
       for (i=0;i<MAX_OBJ_AFFECT;i++) {
 	sprinttype(j->affected[i].location,apply_types,buf2);
-	sprintf(buf,"    Affects : %s By %lu\n\r", buf2,j->affected[i].modifier);
+	SPRINTF(buf,"    Affects : %s By %lu\n\r", buf2,j->affected[i].modifier);
 	send_to_char(buf, ch);
       }			
       return;
@@ -1741,7 +1741,7 @@ void do_set(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       sscanf(parmstr, "%d %d", &parm, &parm2);
       if (mob->skills) {
 	mob->skills[parm].learned = parm2;
-	sprintf(buf, "You just set skill %d to value %d\n\r", parm, parm2);
+	SPRINTF(buf, "You just set skill %d to value %d\n\r", parm, parm2);
 	send_to_char(buf, ch);
       }
 
@@ -1779,11 +1779,11 @@ void do_set(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       if (PeacefulWorks) {
 	PeacefulWorks = FALSE;
 	EasySummon = FALSE;
-	sprintf(buf, "Peaceful rooms and Easy Summon disabled by %s", GET_NAME(ch));
+	SPRINTF(buf, "Peaceful rooms and Easy Summon disabled by %s", GET_NAME(ch));
       } else {
 	PeacefulWorks = TRUE;
 	EasySummon = TRUE;
-	sprintf(buf, "Peaceful rooms and Easy Summon enabled by %s", GET_NAME(ch));
+	SPRINTF(buf, "Peaceful rooms and Easy Summon enabled by %s", GET_NAME(ch));
       }
       log_msg(buf);
 
@@ -1817,12 +1817,12 @@ void do_shutdown(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   one_argument(argument, arg);
   
   if (!*arg) {
-    sprintf(buf, "Shutdown by %s.", GET_NAME(ch) );
+    SPRINTF(buf, "Shutdown by %s.", GET_NAME(ch) );
     send_to_all(buf);
     log_msg(buf);
     mudshutdown = 1;
   } else if (!str_cmp(arg, "reboot")) {
-    sprintf(buf, "Reboot by %s.", GET_NAME(ch));
+    SPRINTF(buf, "Reboot by %s.", GET_NAME(ch));
     send_to_all(buf);
     log_msg(buf);
     mudshutdown = should_reboot = 1;
@@ -1863,7 +1863,7 @@ void do_snoop(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	ch->desc->snoop.snooping->desc->snoop.snoop_by = 0;
       else {
 	char buf[MAX_STRING_LENGTH];
-	sprintf(buf, "caught %s snooping %s who didn't have a descriptor!",
+	SPRINTF(buf, "caught %s snooping %s who didn't have a descriptor!",
 		ch->player.name, ch->desc->snoop.snooping->player.name);
 	log_msg(buf);
 /*
@@ -2013,7 +2013,7 @@ void do_force(struct char_data *ch, char *argument, int cmd)
       if ((GetMaxLevel(ch) <= GetMaxLevel(vict)) && (!IS_NPC(vict)))
 	send_to_char("Oh no you don't!!\n\r", ch);
       else {
-	sprintf(buf, "$n has forced you to '%s'.", to_force);
+	SPRINTF(buf, "$n has forced you to '%s'.", to_force);
 	act(buf, FALSE, ch, 0, vict, TO_VICT);
 	send_to_char("Ok.\n\r", ch);
 	command_interpreter(vict, to_force);
@@ -2027,7 +2027,7 @@ void do_force(struct char_data *ch, char *argument, int cmd)
             (!IS_NPC(vict)))
 	  send_to_char("Oh no you don't!!\n\r", ch);
 	else {
-	  sprintf(buf, "$n has forced you to '%s'.", to_force);
+	  SPRINTF(buf, "$n has forced you to '%s'.", to_force);
 	  act(buf, FALSE, ch, 0, vict, TO_VICT);
 	  command_interpreter(vict, to_force);
 	}
@@ -2908,7 +2908,7 @@ void print_room(int rnum, struct room_data *rp, struct string_block *sb)
   if ((rp->sector_type < 0) || (rp->sector_type > 9)) { /* non-optimal */
     rp->sector_type = 0;
   }
-  sprintf(buf, "%5d %4d %-12s %s", rp->number, rnum,
+  SPRINTF(buf, "%5d %4d %-12s %s", rp->number, rnum,
 	  sector_types[rp->sector_type], (rp->name?rp->name:"Empty"));
   strcat(buf, " [");
 
@@ -2955,7 +2955,7 @@ void show_room_zone(int rnum, struct room_data *rp,
     return; /* optimize later*/
   
   if (srzs->blank && (srzs->lastblank+1 != rp->number) ) {
-    sprintf(buf, "rooms %d-%d are blank\n\r", srzs->startblank, srzs->lastblank);
+    SPRINTF(buf, "rooms %d-%d are blank\n\r", srzs->startblank, srzs->lastblank);
     append_to_string_block(srzs->sb, buf);
     srzs->blank = 0;
   }
@@ -2967,7 +2967,7 @@ void show_room_zone(int rnum, struct room_data *rp,
     }
     return;
   } else if (srzs->blank) {
-    sprintf(buf, "rooms %d-%d are blank\n\r", srzs->startblank, srzs->lastblank);
+    SPRINTF(buf, "rooms %d-%d are blank\n\r", srzs->startblank, srzs->lastblank);
     append_to_string_block(srzs->sb, buf);
     srzs->blank = 0;
   }
@@ -3015,7 +3015,7 @@ void do_show(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	  mode = "!unknown!";
 	}
       }
-      sprintf(buf,"%4d %-40s %4dm %4dm %6d-%-6d %s\n\r", zone, zd->name,
+      SPRINTF(buf,"%4d %-40s %4dm %4dm %6d-%-6d %s\n\r", zone, zd->name,
 	      zd->lifespan, zd->age, bottom, zd->top, mode);
       append_to_string_block(&sb, buf);
       bottom = zd->top+1;
@@ -3049,7 +3049,7 @@ void do_show(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 	  (zone<0 && !isname(zonenum, oi->name)))
 	continue; /* optimize later*/
       
-      sprintf(buf,"%5d %4d %3d  %s\n\r", oi->virtual, objn,
+      SPRINTF(buf,"%5d %4d %3d  %s\n\r", oi->virtual, objn,
 	      oi->number, oi->name);
       append_to_string_block(&sb, buf);
     }
@@ -3094,7 +3094,7 @@ void do_show(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 #endif
 	
       if (srzs.blank){
-	sprintf(buf, "rooms %d-%d are blank\n\r", srzs.startblank,
+	SPRINTF(buf, "rooms %d-%d are blank\n\r", srzs.startblank,
 		srzs.lastblank);
 	append_to_string_block(&sb, buf);
 	srzs.blank = 0;
@@ -3141,7 +3141,7 @@ void do_show(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
     for(i=0;i<10;i++) {
       oi = which_i + top_ten[i];
-      sprintf(buf,"%5d %4d %3d  %s\n\r",
+      SPRINTF(buf,"%5d %4d %3d  %s\n\r",
               oi->virtual, objn,oi->number, oi->name);
       append_to_string_block(&sb, buf);
     }
@@ -3168,9 +3168,9 @@ void do_debug(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   } else {
 #if DEBUG
     malloc_debug(i);
-    sprintf(arg, "malloc debug level set to %d\n\r", i);
+    SPRINTF(arg, "malloc debug level set to %d\n\r", i);
 #else
-    sprintf(arg, "Debug level set to %d. May not be implemented\n\r", i);
+    SPRINTF(arg, "Debug level set to %d. May not be implemented\n\r", i);
 #endif
     send_to_char(arg, ch);
   }
@@ -3196,7 +3196,7 @@ void do_invis(struct char_data *ch, char *argument, int cmd)
     if (level<0) level=0;
     else if (level>LOW_IMMORTAL) level = LOW_IMMORTAL;
     ch->invis_level = level;
-    sprintf(buf,"Invis level set to %d.\n\r", level);
+    SPRINTF(buf,"Invis level set to %d.\n\r", level);
     send_to_char(buf, ch);
   } else {
     if (ch->invis_level>0) {
@@ -3261,7 +3261,7 @@ void CreateOneRoom( int loc_nr)
     }
     rp->zone = zone;
   }
-  sprintf(buf, "%d", loc_nr);
+  SPRINTF(buf, "%d", loc_nr);
   rp->name = (char *)strdup(buf);
   rp->description = (char *)strdup("Empty\n");
 }
@@ -3350,15 +3350,15 @@ void do_beep(struct char_data *ch, char *argument, int UNUSED(cmd)) {
  }
 
  if(IS_SET(victim->specials.act, PLR_NOBEEP)) {
-   sprintf(buf, "%s can not be beeped right now.\n\r", GET_NAME(victim));
+   SPRINTF(buf, "%s can not be beeped right now.\n\r", GET_NAME(victim));
    send_to_char(buf, ch);
    return;
  }
 
  else {
-   sprintf(buf, "%c%s is beeping you.\n\r", 7, GET_NAME(ch));
+   SPRINTF(buf, "%c%s is beeping you.\n\r", 7, GET_NAME(ch));
    send_to_char(buf, victim);
-   sprintf(buf, "%s has been beeped.\n\r", GET_NAME(victim));
+   SPRINTF(buf, "%s has been beeped.\n\r", GET_NAME(victim));
    send_to_char(buf, ch);
    return;
  }
@@ -3393,7 +3393,7 @@ void do_cset(struct char_data *ch, char *arg, int UNUSED(cmd)) {
        send_to_char("Sorry, command not found.\n\r", ch);
        return;
      }
-    sprintf(buf, "Name: %s\n\rMinimum Position: %d\n\rMinimum Level: %d\n\rNumber: %d\n\rLog Bit: %s\n\r",
+    SPRINTF(buf, "Name: %s\n\rMinimum Position: %d\n\rMinimum Level: %d\n\rNumber: %d\n\rLog Bit: %s\n\r",
             n->name, n->min_pos, n->min_level, n->number, (n->log ? "On" : "Off"));
     send_to_char(buf, ch);
     return;

--- a/src/board.c
+++ b/src/board.c
@@ -195,7 +195,7 @@ void board_write_msg(struct char_data *ch, char *arg, int bnum) {
   ct = time(0);
   tmstr = (char *)asctime(localtime(&ct));
   *(tmstr + strlen(tmstr) - 1) = '\0';
-  sprintf(buf,"%.10s",tmstr);
+  SPRINTF(buf,"%.10s",tmstr);
   curr_msg->date = (char *)malloc(strlen(buf)+1);
   strcpy(curr_msg->date, buf);
   send_to_char("Write your message. Terminate with a @.\n\r\n\r", ch);
@@ -286,12 +286,13 @@ int board_remove_msg(struct char_data *ch, char *arg, int bnum) {
   curr_board->number--;
 
   send_to_char("Message removed.\n\r", ch);
-  sprintf(buf, "%s just removed message %d.", ch->player.name, tmessage);
+  SPRINTF(buf, "%s just removed message %d.", ch->player.name, tmessage);
 
   /* Removal message also repaired */
 
   act(buf, FALSE, ch, 0, 0, TO_ROOM);
-  sprintf((buf+strlen(buf)-1)," from board %d.",bnum);
+  buf[strlen(buf)-1] = '\0';
+  SAPPENDF(buf, " from board %d.",bnum);
   log_msg(buf);  /* Message removals now logged. */
 
   board_save_board(bnum);
@@ -382,7 +383,7 @@ void board_load_board() {
     boards[bnum].number = -1;
     the_file = fopen(save_file[bnum], "r");
     if (!the_file) {
-      sprintf(buf,"Can't open message file for board %d.\n\r",bnum);
+      SPRINTF(buf,"Can't open message file for board %d.\n\r",bnum);
       log_msg(buf);
       continue;
     }
@@ -449,13 +450,13 @@ int board_display_msg(struct char_data *ch, char *arg, int bnum)
 
   curr_msg = &curr_board->msg[tmessage];
 
-  sprintf(buffer, "Message %2d (%s): %-15s -- %s", tmessage, curr_msg->date, curr_msg->author, curr_msg->title );
-  sprintf(buffer + strlen(buffer), "\n\r----------\n\r%s", (curr_msg->text?curr_msg->text:"(null)"));
+  SPRINTF(buffer, "Message %2d (%s): %-15s -- %s", tmessage, curr_msg->date, curr_msg->author, curr_msg->title );
+  SAPPENDF(buffer, "\n\r----------\n\r%s", (curr_msg->text?curr_msg->text:"(null)"));
   page_string(ch->desc, buffer, 1);
   return(1);
 
 /*
-  sprintf(buf, "$n reads message %d titled : %s.",tmessage, curr_msg->title);
+  SPRINTF(buf, "$n reads message %d titled : %s.",tmessage, curr_msg->title);
   act(buf, TRUE, ch, 0, 0, TO_ROOM);
 */
 }
@@ -487,14 +488,14 @@ int board_show_board(struct char_data *ch, char *arg, int bnum)
   if (boards[bnum].number == -1)
     strcat(buf, "The board is empty.\n\r");
   else {
-    sprintf(buf + strlen(buf), "There are %d messages on the board.\n\r",
+    SAPPENDF(buf, "There are %d messages on the board.\n\r",
 	    curr_board->number);
-    sprintf(buf + strlen(buf), "\n\rBoard Topic:\n\r%s------------\n\r",curr_board->msg[0].text);
+    SAPPENDF(buf, "\n\rBoard Topic:\n\r%s------------\n\r",curr_board->msg[0].text);
     for ( i = 1 ; i <= curr_board->number ; i++ ) 
 /*      if (((GET_MAX_LEVEL(ch) < min_read_level[bnum]) &&
            (strcmp(ch->name, curr_board->msg[i].author))) ||
           (GET_MAX_LEVEL(ch) >= min_read_level[bnum]))  */
-       sprintf(buf + strlen(buf), "%-2d : %-15s (%s) -- %s\n\r", i , 
+      SAPPENDF(buf, "%-2d : %-15s (%s) -- %s\n\r", i , 
                curr_board->msg[i].author, curr_board->msg[i].date,
                curr_board->msg[i].title);
   }
@@ -534,14 +535,14 @@ int board_check_locks (int bnum, struct char_data *ch) {
   /* Check for link-death of lock holder */
 
   if (!board_lock[bnum].locked_for->desc) {
-    sprintf(buf,"You push %s aside and approach the board.\n\r",board_lock[bnum].locked_for->player.name);
+    SPRINTF(buf,"You push %s aside and approach the board.\n\r",board_lock[bnum].locked_for->player.name);
     send_to_char(buf, ch);
   }
 
   /* Else see if lock holder is still in write-string mode */
 
   else if (board_lock[bnum].locked_for->desc->str) { /* Lock still holding */
-    sprintf(buf,"You try to approach the board but %s blocks your way.\n\r",board_lock[bnum].locked_for->player.name);
+    SPRINTF(buf,"You try to approach the board but %s blocks your way.\n\r",board_lock[bnum].locked_for->player.name);
     send_to_char(buf, ch);
     return (1);
   }

--- a/src/comm.c
+++ b/src/comm.c
@@ -152,7 +152,7 @@ int real_main (int argc, char **argv)
       log_msg("Suppressing assignment of special routines.");
       break;
     default:
-      sprintf(buf, "Unknown option -% in argument string.",
+      SPRINTF(buf, "Unknown option -% in argument string.",
 	      *(argv[pos] + 1));
       log_msg(buf);
       break;
@@ -175,7 +175,7 @@ int real_main (int argc, char **argv)
   
   Uptime = time(0);
   
-  sprintf(buf, "Running game on port %d.", port);
+  SPRINTF(buf, "Running game on port %d.", port);
   log_msg(buf);
   
   if (chdir(dir) < 0)	{
@@ -183,7 +183,7 @@ int real_main (int argc, char **argv)
     assert(0);
   }
   
-  sprintf(buf, "Using %s as data directory.", dir);
+  SPRINTF(buf, "Using %s as data directory.", dir);
   log_msg(buf);
   
   srandom(time(0));
@@ -532,7 +532,7 @@ void game_loop(int s)
 		}
 
 		if(IS_SET(ch->specials.prompt, PROMPT_R)) {
-		  sprintf(promptbuf,"<Rm: %d ", rm->number);
+		  SPRINTF(promptbuf,"<Rm: %d ", rm->number);
 		  write_to_descriptor(point->descriptor, promptbuf);
 		}
                 if(IS_SET(ch->specials.prompt, PROMPT_S)) {
@@ -544,29 +544,29 @@ void game_loop(int s)
 		  sprintbit((unsigned long)rm->room_flags,room_bits,promptbuf);
 		  write_to_descriptor(point->descriptor, promptbuf);
 		}
-		sprintf(promptbuf, "> ");
+		SPRINTF(promptbuf, "> ");
 		write_to_descriptor(point->descriptor, promptbuf);
 	      } else {
 		if(IS_SET(ch->specials.prompt, PROMPT_H)) {
-		  sprintf(promptbuf,"H:%d ",
+		  SPRINTF(promptbuf,"H:%d ",
 			  point->character->points.hit);
 		  write_to_descriptor(point->descriptor, promptbuf);
 		}
 		if(IS_SET(ch->specials.prompt, PROMPT_M)) {
-		  sprintf(promptbuf,"M:%d ",
+		  SPRINTF(promptbuf,"M:%d ",
 			  point->character->points.mana);
 		  write_to_descriptor(point->descriptor, promptbuf);
 		}
 		if(IS_SET(ch->specials.prompt, PROMPT_V)) {
-		  sprintf(promptbuf,"V:%d ",
+		  SPRINTF(promptbuf,"V:%d ",
 			  point->character->points.move);
 		  write_to_descriptor(point->descriptor, promptbuf);
 		}
-		sprintf(promptbuf, "> ");
+		SPRINTF(promptbuf, "> ");
 		write_to_descriptor(point->descriptor, promptbuf);
 	      }
 	    } else {
-	      sprintf(promptbuf, "> ");
+	      SPRINTF(promptbuf, "> ");
 	      write_to_descriptor(point->descriptor, promptbuf);
 	    }
 	  }
@@ -809,7 +809,7 @@ int new_connection(int s)
   if (!getpeername(t, &peer, &i))	{
     if (i > 0) {
       *(peer.sa_data + 49) = '\0';
-      sprintf(buf, "New connection from addr %s.", peer.sa_data);
+      SPRINTF(buf, "New connection from addr %s.", peer.sa_data);
       log_msg(buf);
     }
   }
@@ -867,12 +867,12 @@ int new_descriptor(int s)
 #ifndef sun
     if ((long) strncpy(newd->host, inet_ntoa(sock.sin_addr), 49) > 0)  {
       *(newd->host + 49) = '\0';
-      sprintf(buf, "New connection from addr %s: %d: %d", newd->host, desc, maxdesc);
+      SPRINTF(buf, "New connection from addr %s: %d: %d", newd->host, desc, maxdesc);
       log_sev(buf,3);
     }
 #else
     strcpy(newd->host, (char *)inet_ntoa(&sock.sin_addr));
-    sprintf(buf, "New connection from addr %s: %d: %d", newd->host, desc, maxdesc);
+    SPRINTF(buf, "New connection from addr %s: %d: %d", newd->host, desc, maxdesc);
     log_sev(buf,3);
 #endif
   }
@@ -1038,7 +1038,7 @@ int process_input(struct descriptor_data *t)
 	}
 	
 	if (flag) {
-	  sprintf(buffer, 
+	  SPRINTF(buffer, 
 		  "Line too long. Truncated to:\n\r%s\n\r", tmp);
 	  if (write_to_descriptor(t->descriptor, buffer) < 0)
 	    return(-1);
@@ -1107,7 +1107,7 @@ void close_socket(struct descriptor_data *d)
     if (d->connected == CON_PLYNG) 	{
        do_save(d->character, "", 0);
       act("$n has lost $s link.", TRUE, d->character, 0, 0, TO_ROOM);
-      sprintf(buf, "Closing link to: %s.", GET_NAME(d->character));
+      SPRINTF(buf, "Closing link to: %s.", GET_NAME(d->character));
       log_msg(buf);
       if (IS_NPC(d->character)) { /* poly, or switched god */
 	if (d->character->desc)
@@ -1124,7 +1124,7 @@ void close_socket(struct descriptor_data *d)
 
     } else {
       if (GET_NAME(d->character)) {
-	sprintf(buf, "Losing player: %s.", GET_NAME(d->character));
+	SPRINTF(buf, "Losing player: %s.", GET_NAME(d->character));
 	log_msg(buf);
       }
       free_char(d->character);
@@ -1565,7 +1565,7 @@ void raw_force_all( char *to_force)
 
   for (i = descriptor_list; i; i = i->next)
     if (!i->connected) {
-      sprintf(buf, "The game has forced you to '%s'.\n\r", to_force);
+      SPRINTF(buf, "The game has forced you to '%s'.\n\r", to_force);
       send_to_char(buf, i->character);
       command_interpreter(i->character, to_force);
     }
@@ -1583,77 +1583,77 @@ void UpdateScreen(struct char_data *ch, int update)
  size = ch->size;
 
  if(IS_SET(update, INFO_MANA)) {
-    sprintf(buf, VT_CURSAVE);
+    SPRINTF(buf, VT_CURSAVE);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 2, 7);
+    SPRINTF(buf, VT_CURSPOS, size - 2, 7);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "          ");
+    SPRINTF(buf, "          ");
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 2, 7);
+    SPRINTF(buf, VT_CURSPOS, size - 2, 7);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "%d(%d)", GET_MANA(ch), GET_MAX_MANA(ch));
+    SPRINTF(buf, "%d(%d)", GET_MANA(ch), GET_MAX_MANA(ch));
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURREST);
+    SPRINTF(buf, VT_CURREST);
     write_to_descriptor(ch->desc->descriptor, buf);
   }
  
  if(IS_SET(update, INFO_MOVE)) {
-    sprintf(buf, VT_CURSAVE);
+    SPRINTF(buf, VT_CURSAVE);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 3, 58);
+    SPRINTF(buf, VT_CURSPOS, size - 3, 58);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "          ");
+    SPRINTF(buf, "          ");
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 3, 58);
+    SPRINTF(buf, VT_CURSPOS, size - 3, 58);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "%d(%d)", GET_MOVE(ch), GET_MAX_MOVE(ch));
+    SPRINTF(buf, "%d(%d)", GET_MOVE(ch), GET_MAX_MOVE(ch));
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURREST);
+    SPRINTF(buf, VT_CURREST);
     write_to_descriptor(ch->desc->descriptor, buf);
   }
  
  if(IS_SET(update, INFO_HP)) {
-    sprintf(buf, VT_CURSAVE);
+    SPRINTF(buf, VT_CURSAVE);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 3, 13);
+    SPRINTF(buf, VT_CURSPOS, size - 3, 13);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "          ");
+    SPRINTF(buf, "          ");
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 3, 13);
+    SPRINTF(buf, VT_CURSPOS, size - 3, 13);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "%d(%d)", GET_HIT(ch), GET_MAX_HIT(ch));
+    SPRINTF(buf, "%d(%d)", GET_HIT(ch), GET_MAX_HIT(ch));
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURREST);
+    SPRINTF(buf, VT_CURREST);
     write_to_descriptor(ch->desc->descriptor, buf);
   }
  
  if(IS_SET(update, INFO_GOLD)) {
-    sprintf(buf, VT_CURSAVE);
+    SPRINTF(buf, VT_CURSAVE);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 2, 47);
+    SPRINTF(buf, VT_CURSPOS, size - 2, 47);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "                ");
+    SPRINTF(buf, "                ");
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 2, 47);
+    SPRINTF(buf, VT_CURSPOS, size - 2, 47);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "%d", GET_GOLD(ch));
+    SPRINTF(buf, "%d", GET_GOLD(ch));
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURREST);
+    SPRINTF(buf, VT_CURREST);
     write_to_descriptor(ch->desc->descriptor, buf);
   }
  
  if(IS_SET(update, INFO_EXP)) {
-    sprintf(buf, VT_CURSAVE);
+    SPRINTF(buf, VT_CURSAVE);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 1, 20);
+    SPRINTF(buf, VT_CURSPOS, size - 1, 20);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "                ");
+    SPRINTF(buf, "                ");
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURSPOS, size - 1, 20);
+    SPRINTF(buf, VT_CURSPOS, size - 1, 20);
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, "%d", GET_EXP(ch));
+    SPRINTF(buf, "%d", GET_EXP(ch));
     write_to_descriptor(ch->desc->descriptor, buf);
-    sprintf(buf, VT_CURREST);
+    SPRINTF(buf, VT_CURREST);
     write_to_descriptor(ch->desc->descriptor, buf);
   }
 }
@@ -1665,33 +1665,33 @@ void InitScreen(struct char_data *ch)
  int size;
 
  size = ch->size; 
- sprintf(buf, VT_HOMECLR);
+ SPRINTF(buf, VT_HOMECLR);
  send_to_char(buf, ch);
- sprintf(buf, VT_MARGSET, 0, size - 5);
+ SPRINTF(buf, VT_MARGSET, 0, size - 5);
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 4, 1);
+ SPRINTF(buf, VT_CURSPOS, size - 4, 1);
  send_to_char(buf, ch);
- sprintf(buf, "-===========================================================================-");
+ SPRINTF(buf, "-===========================================================================-");
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 3, 1);
+ SPRINTF(buf, VT_CURSPOS, size - 3, 1);
  send_to_char(buf, ch);
- sprintf(buf, "Hit Points: ");
+ SPRINTF(buf, "Hit Points: ");
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 3, 40);
+ SPRINTF(buf, VT_CURSPOS, size - 3, 40);
  send_to_char(buf, ch);
- sprintf(buf, "Movement Points: ");
+ SPRINTF(buf, "Movement Points: ");
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 2, 1);
+ SPRINTF(buf, VT_CURSPOS, size - 2, 1);
  send_to_char(buf, ch);
- sprintf(buf, "Mana: ");
+ SPRINTF(buf, "Mana: ");
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 2, 40);
+ SPRINTF(buf, VT_CURSPOS, size - 2, 40);
  send_to_char(buf, ch);
- sprintf(buf, "Gold: ");
+ SPRINTF(buf, "Gold: ");
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 1, 1);
+ SPRINTF(buf, VT_CURSPOS, size - 1, 1);
  send_to_char(buf, ch);
- sprintf(buf, "Experience Points: ");
+ SPRINTF(buf, "Experience Points: ");
  send_to_char(buf, ch);
  
  ch->last.mana = GET_MANA(ch);
@@ -1704,28 +1704,28 @@ void InitScreen(struct char_data *ch)
  ch->last.gold = GET_GOLD(ch);
  
  /* Update all of the info parts */
- sprintf(buf, VT_CURSPOS, size - 3, 13);
+ SPRINTF(buf, VT_CURSPOS, size - 3, 13);
  send_to_char(buf, ch);
- sprintf(buf, "%d(%d)", GET_HIT(ch), GET_MAX_HIT(ch));
+ SPRINTF(buf, "%d(%d)", GET_HIT(ch), GET_MAX_HIT(ch));
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 3, 58);
+ SPRINTF(buf, VT_CURSPOS, size - 3, 58);
  send_to_char(buf, ch);
- sprintf(buf, "%d(%d)", GET_MOVE(ch), GET_MAX_MOVE(ch));
+ SPRINTF(buf, "%d(%d)", GET_MOVE(ch), GET_MAX_MOVE(ch));
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 2, 7);
+ SPRINTF(buf, VT_CURSPOS, size - 2, 7);
  send_to_char(buf, ch);
- sprintf(buf, "%d(%d)", GET_MANA(ch), GET_MAX_MANA(ch));
+ SPRINTF(buf, "%d(%d)", GET_MANA(ch), GET_MAX_MANA(ch));
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 2, 47);
+ SPRINTF(buf, VT_CURSPOS, size - 2, 47);
  send_to_char(buf, ch);
- sprintf(buf, "%d", GET_GOLD(ch));
+ SPRINTF(buf, "%d", GET_GOLD(ch));
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, size - 1, 20);
+ SPRINTF(buf, VT_CURSPOS, size - 1, 20);
  send_to_char(buf, ch);
- sprintf(buf, "%d", GET_EXP(ch));
+ SPRINTF(buf, "%d", GET_EXP(ch));
  send_to_char(buf, ch);
 
- sprintf(buf, VT_CURSPOS, 0, 0);
+ SPRINTF(buf, VT_CURSPOS, 0, 0);
  send_to_char(buf, ch);
 
 }

--- a/src/create.c
+++ b/src/create.c
@@ -81,22 +81,22 @@ void ChangeRoomFlags(struct room_data *rp, struct char_data *ch, char *arg, int 
        SET_BIT(rp->room_flags, i);
   }
  
- sprintf(buf, VT_HOMECLR);
+ SPRINTF(buf, VT_HOMECLR);
  send_to_char(buf, ch);
- sprintf(buf, "Room Flags:");
+ SPRINTF(buf, "Room Flags:");
  send_to_char(buf, ch);
  
  row = 0;
  for(i = 0; i < 14; i++) {
-    sprintf(buf, VT_CURSPOS, row + 4, ((i & 1) ? 45 : 5));
+    SPRINTF(buf, VT_CURSPOS, row + 4, ((i & 1) ? 45 : 5));
     if(i & 1)
        row++;
     send_to_char(buf, ch);
-    sprintf(buf, "%-2d [%s] %s", i + 1, ((rp->room_flags & (1<<i)) ? "X" : " "), room_bits[i]);
+    SPRINTF(buf, "%-2d [%s] %s", i + 1, ((rp->room_flags & (1<<i)) ? "X" : " "), room_bits[i]);
     send_to_char(buf, ch);
   }
  
- sprintf(buf, VT_CURSPOS, 20, 1);
+ SPRINTF(buf, VT_CURSPOS, 20, 1);
  send_to_char(buf, ch);
  send_to_char("Select the number to toggle, <C/R> to return to main menu.\n\r--> ", ch);
 }
@@ -141,19 +141,19 @@ void UpdateRoomMenu(struct char_data *ch)
  rp = real_roomp(ch->in_room);
  
  send_to_char(VT_HOMECLR, ch);
- sprintf(buf, VT_CURSPOS, 1, 1);
+ SPRINTF(buf, VT_CURSPOS, 1, 1);
  send_to_char(buf, ch);
- sprintf(buf, "Room Name: %s", rp->name);
+ SPRINTF(buf, "Room Name: %s", rp->name);
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, 1, 40);
+ SPRINTF(buf, VT_CURSPOS, 1, 40);
  send_to_char(buf, ch);
- sprintf(buf, "Number: %d", rp->number);
+ SPRINTF(buf, "Number: %d", rp->number);
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, 1, 60);
+ SPRINTF(buf, VT_CURSPOS, 1, 60);
  send_to_char(buf, ch);
- sprintf(buf, "Sector Type: %s", sector_types[rp->sector_type]);
+ SPRINTF(buf, "Sector Type: %s", sector_types[rp->sector_type]);
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, 3, 1);
+ SPRINTF(buf, VT_CURSPOS, 3, 1);
  send_to_char(buf, ch);
  send_to_char("Menu:\n\r", ch);
  send_to_char(edit_menu, ch);
@@ -252,10 +252,10 @@ void ChangeRoomName(struct room_data *rp, struct char_data *ch, char *arg, int t
     return;
  }
  
- sprintf(buf, VT_HOMECLR);
+ SPRINTF(buf, VT_HOMECLR);
  send_to_char(buf, ch);
  
- sprintf(buf, "Current Room Name: %s", rp->name);
+ SPRINTF(buf, "Current Room Name: %s", rp->name);
  send_to_char(buf, ch);
  send_to_char("\n\r\n\rNew Room Name: ", ch);
  
@@ -272,10 +272,10 @@ void ChangeRoomDesc(struct room_data *rp, struct char_data *ch,
     return;
  }
  
- sprintf(buf, VT_HOMECLR);
+ SPRINTF(buf, VT_HOMECLR);
  send_to_char(buf, ch);
  
- sprintf(buf, "Current Room Description:\n\r");
+ SPRINTF(buf, "Current Room Description:\n\r");
  send_to_char(buf, ch);
  send_to_char(rp->description, ch);
  send_to_char("\n\r\n\rNew Room Description:\n\r", ch);
@@ -335,22 +335,22 @@ void ChangeRoomType(struct room_data *rp, struct char_data *ch, char *arg, int t
     }
    }
  
- sprintf(buf, VT_HOMECLR);
+ SPRINTF(buf, VT_HOMECLR);
  send_to_char(buf, ch);
- sprintf(buf, "Sector Type: %s", sector_types[rp->sector_type]);
+ SPRINTF(buf, "Sector Type: %s", sector_types[rp->sector_type]);
  send_to_char(buf, ch);
  
  row = 0;
  for(i = 0; i < 12; i++) {
-    sprintf(buf, VT_CURSPOS, row + 4, ((i & 1) ? 45 : 5));
+    SPRINTF(buf, VT_CURSPOS, row + 4, ((i & 1) ? 45 : 5));
     if(i & 1)
        row++;
     send_to_char(buf, ch);
-    sprintf(buf, "%-2d %s", i + 1, sector_types[i]);
+    SPRINTF(buf, "%-2d %s", i + 1, sector_types[i]);
     send_to_char(buf, ch);
   }
  
- sprintf(buf, VT_CURSPOS, 20, 1);
+ SPRINTF(buf, VT_CURSPOS, 20, 1);
  send_to_char(buf, ch);
  send_to_char("Select the number to set to, <C/R> to return to main menu.\n\r--> ", ch);
 }
@@ -411,13 +411,13 @@ void ChangeExitDir(struct room_data *rp, struct char_data *ch, char *arg, int ty
  
  
  send_to_char(VT_HOMECLR, ch);
- sprintf(buf, "Room Name: %s", rp->name);
+ SPRINTF(buf, "Room Name: %s", rp->name);
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, 1, 40);
+ SPRINTF(buf, VT_CURSPOS, 1, 40);
  send_to_char(buf, ch);
- sprintf(buf, "Room Number: %d", rp->number);
+ SPRINTF(buf, "Room Number: %d", rp->number);
  send_to_char(buf, ch);
- sprintf(buf, VT_CURSPOS, 4, 1);
+ SPRINTF(buf, VT_CURSPOS, 4, 1);
  send_to_char(buf, ch);
  send_to_char(exit_menu, ch);
  send_to_char("--> ", ch);
@@ -485,23 +485,23 @@ void AddExitToRoom(struct room_data *rp, struct char_data *ch, char *arg, int ty
     rp->dir_option[dir]->exit_info = 0;
  }
  
- sprintf(buf, VT_HOMECLR);
+ SPRINTF(buf, VT_HOMECLR);
  send_to_char(buf, ch);
- sprintf(buf, "Exit Flags:");
+ SPRINTF(buf, "Exit Flags:");
  send_to_char(buf, ch);
  
  row = 0;
  for(i = 0; i < 7; i++) {
-    sprintf(buf, VT_CURSPOS, row + 4, ((i & 1) ? 45 : 5));
+    SPRINTF(buf, VT_CURSPOS, row + 4, ((i & 1) ? 45 : 5));
     if(i & 1)
        row++;
     send_to_char(buf, ch);
-    sprintf(buf, "%-2d [%s] %s", i + 1, ((rp->dir_option[dir]->exit_info & (1<<i)) ? "X" : " "), 
+    SPRINTF(buf, "%-2d [%s] %s", i + 1, ((rp->dir_option[dir]->exit_info & (1<<i)) ? "X" : " "), 
             exit_bits[i]);
     send_to_char(buf, ch);
   }
  
- sprintf(buf, VT_CURSPOS, 20, 1);
+ SPRINTF(buf, VT_CURSPOS, 20, 1);
  send_to_char(buf, ch);
  send_to_char("Select the number to toggle, <C/R> to return to continue.\n\r--> ", ch);
 }

--- a/src/db.c
+++ b/src/db.c
@@ -294,7 +294,7 @@ void reset_time()
 		}
 	}
 
-	sprintf(buf,"   Current Gametime: %dH %dD %dM %dY.",
+	SPRINTF(buf,"   Current Gametime: %dH %dD %dM %dY.",
 	        time_info.hours, time_info.day,
 	        time_info.month, time_info.year);
 	log_msg(buf);
@@ -390,7 +390,7 @@ void build_player_index()
 		   LOWER(*(dummy.name + i))) != '\0'; i++);
 
       for (i = 0; i <= 5; i++) if (dummy.level[i] >= 51) {
-	sprintf(buf,"GOD: %s, Levels [%d][%d][%d][%d][%d][%d]",dummy.name,
+	SPRINTF(buf,"GOD: %s, Levels [%d][%d][%d][%d][%d][%d]",dummy.name,
 		dummy.level[0],dummy.level[1],dummy.level[2],dummy.level[3],
 		dummy.level[4],dummy.level[5]);
 	log_msg(buf);
@@ -420,8 +420,8 @@ void build_player_index()
 
   log_msg("Began Wizlist Generation.");
 
-  sprintf(wizlist, "\033[2J\033[0;0H\n\r\n\r");
-  sprintf(buf, "-* Creator and Supreme Being [%d/1] *-\n\r",list_wiz.number[10]);
+  SPRINTF(wizlist, "\033[2J\033[0;0H\n\r\n\r");
+  SPRINTF(buf, "-* Creator and Supreme Being [%d/1] *-\n\r",list_wiz.number[10]);
 
   
   center = (38 - (int) (str_len(buf)/2));
@@ -433,7 +433,7 @@ void build_player_index()
 
 
   for(i = 0; i < list_wiz.number[10]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[10].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[10].stuff[i].name,
              list_wiz.lookup[10].stuff[i].title);
 
      center = 38 - (int) (str_len(buf)/2);
@@ -445,7 +445,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
   log_msg("Creator Generated.");
 
-  sprintf(buf, "-* Designers/Administrators [%d/2] *-\n\r", list_wiz.number[9]);
+  SPRINTF(buf, "-* Designers/Administrators [%d/2] *-\n\r", list_wiz.number[9]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -453,7 +453,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[9]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[9].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[9].stuff[i].name,
              list_wiz.lookup[9].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -463,7 +463,7 @@ void build_player_index()
 
   strcat(wizlist, "\n\r\n\r");
 
-  sprintf(buf, "-* Implementors [%d/5] *-\n\r", list_wiz.number[8]);
+  SPRINTF(buf, "-* Implementors [%d/5] *-\n\r", list_wiz.number[8]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -471,7 +471,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[8]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[8].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[8].stuff[i].name,
              list_wiz.lookup[8].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -482,7 +482,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
   log_msg("Implementors Generated.");
 
-  sprintf(buf, "-* Gods of Final Judgement [%d/6] *-\n\r", list_wiz.number[7]);
+  SPRINTF(buf, "-* Gods of Final Judgement [%d/6] *-\n\r", list_wiz.number[7]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -490,7 +490,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[7]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[7].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[7].stuff[i].name,
              list_wiz.lookup[7].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -501,7 +501,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
   log_msg("Gods of Final Judgement Generated.");
 
-  sprintf(buf, "-* Gods of Judgement [%d/8] *-\n\r", list_wiz.number[6]);
+  SPRINTF(buf, "-* Gods of Judgement [%d/8] *-\n\r", list_wiz.number[6]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -509,7 +509,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[6]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[6].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[6].stuff[i].name,
              list_wiz.lookup[6].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -520,7 +520,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
 
 
-  sprintf(buf, "-* Greater Gods [%d/10] *-\n\r", list_wiz.number[5]);
+  SPRINTF(buf, "-* Greater Gods [%d/10] *-\n\r", list_wiz.number[5]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -528,7 +528,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[5]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[5].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[5].stuff[i].name,
              list_wiz.lookup[5].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -539,7 +539,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
 
 
-  sprintf(buf, "-* Gods [%d/12] *-\n\r", list_wiz.number[4]);
+  SPRINTF(buf, "-* Gods [%d/12] *-\n\r", list_wiz.number[4]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -547,7 +547,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[4]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[4].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[4].stuff[i].name,
              list_wiz.lookup[4].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -558,7 +558,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
 
 
-  sprintf(buf, "-* Demi-Gods [%d/14] *-\n\r", list_wiz.number[3]);
+  SPRINTF(buf, "-* Demi-Gods [%d/14] *-\n\r", list_wiz.number[3]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -566,7 +566,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[3]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[3].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[3].stuff[i].name,
              list_wiz.lookup[3].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -577,7 +577,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
 
 
-  sprintf(buf, "-* Saints [%d/30] *-\n\r", list_wiz.number[2]);
+  SPRINTF(buf, "-* Saints [%d/30] *-\n\r", list_wiz.number[2]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -585,7 +585,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[2]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[2].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[2].stuff[i].name,
              list_wiz.lookup[2].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -596,7 +596,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
 
 
-  sprintf(buf, "-* Immortals of Creation [%d/50] *-\n\r", list_wiz.number[1]);
+  SPRINTF(buf, "-* Immortals of Creation [%d/50] *-\n\r", list_wiz.number[1]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -604,7 +604,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[1]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[1].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[1].stuff[i].name,
              list_wiz.lookup[1].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -615,7 +615,7 @@ void build_player_index()
   strcat(wizlist, "\n\r\n\r");
 
 
-  sprintf(buf, "-* Immortals [%d/~] *-\n\r", list_wiz.number[0]);
+  SPRINTF(buf, "-* Immortals [%d/~] *-\n\r", list_wiz.number[0]);
   center = 38 - (int) (str_len(buf)/2);
 
   for(i = 0; i <= center; i++)
@@ -623,7 +623,7 @@ void build_player_index()
   strcat(wizlist, buf);
 
   for(i = 0; i < list_wiz.number[0]; i++) {
-     sprintf(buf, "%s %s\n\r", list_wiz.lookup[0].stuff[i].name,
+     SPRINTF(buf, "%s %s\n\r", list_wiz.lookup[0].stuff[i].name,
              list_wiz.lookup[0].stuff[i].title);
      center = 38 - (int) (str_len(buf)/2);
      for(j = 0; j <= center; j++)
@@ -635,7 +635,7 @@ void build_player_index()
   max = 0;
   for(i = 0; i <= 9; i++)
     max += list_wiz.number[i];
-  sprintf(buf, "Total Gods: %d\n\r\n\r", max);
+  SPRINTF(buf, "Total Gods: %d\n\r\n\r", max);
   strcat(wizlist, buf);
 
   return;
@@ -861,7 +861,7 @@ void load_one_room(FILE *fl, struct room_data *rp)
        FILE *fp;
        char buf[255];
 
-       sprintf(buf, "world/%d", rp->number);
+       SPRINTF(buf, "world/%d", rp->number);
        fp = fopen(buf, "r");
        if(fp) {
           saved_rooms[number_of_saved_rooms] = rp->number;
@@ -872,7 +872,7 @@ void load_one_room(FILE *fl, struct room_data *rp)
 #endif
       return;
     default:
-      sprintf(buf,"unknown auxiliary code `%s' in room load of #%d",
+      SPRINTF(buf,"unknown auxiliary code `%s' in room load of #%d",
 	      chk, rp->number);
       log_msg(buf);
       break;
@@ -1001,7 +1001,7 @@ void setup_dir(FILE *fl, int room, int dir)
 
 
 #define LOG_ZONE_ERROR(ch, type, zone, cmd) {\
-	sprintf(buf, "error in zone %s cmd %d (%c) resolving %s number", \
+	SPRINTF(buf, "error in zone %s cmd %d (%c) resolving %s number", \
 		zone_table[zone].name, cmd, ch, type); \
 		  log_msg(buf); \
 		  }
@@ -1201,7 +1201,7 @@ struct char_data *read_mobile(int nr, int type)
   i = nr;
   if (type == VIRTUAL)
     if ((nr = real_mobile(nr)) < 0)	{
-      sprintf(buf, "Mobile (V) %d does not exist in database.", i);
+      SPRINTF(buf, "Mobile (V) %d does not exist in database.", i);
       return(0);
     }
   
@@ -1600,7 +1600,7 @@ struct char_data *read_mobile(int nr, int type)
   for(i = 0; i < top_of_scripts; i++) {
     if(script_data[i].virtual == mob_index[nr].virtual) {
       SET_BIT(mob->specials.act, ACT_SCRIPT);
-      /* sprintf(buffer, "Setting SCRIPT bit for mobile %s, file %s.", GET_NAME(mob), script_data[i].filename);
+      /* SPRINTF(buffer, "Setting SCRIPT bit for mobile %s, file %s.", GET_NAME(mob), script_data[i].filename);
 	 log_msg(buffer); */
       mob->script = i;
       break;
@@ -1627,7 +1627,7 @@ struct char_data *read_mobile(int nr, int type)
 
   if (mob->points.gold > GET_LEVEL(mob, WARRIOR_LEVEL_IND)*1500) {
     char buf[200];
-    sprintf(buf, "%s has gold > level * 1500 (%d)", mob->player.short_descr,
+    SPRINTF(buf, "%s has gold > level * 1500 (%d)", mob->player.short_descr,
 	    mob->points.gold);
     log_msg(buf);
   }
@@ -1686,7 +1686,7 @@ struct obj_data *read_object(int nr, int type)
     nr = real_object(nr);
   }
   if (nr<0 || nr>top_of_objt) {
-    sprintf(buf, "Object (V) %d does not exist in database.", i);
+    SPRINTF(buf, "Object (V) %d does not exist in database.", i);
     return(0);
   }
   
@@ -1917,7 +1917,7 @@ void reset_zone(int zone)
     done = 1;
 #if SAVE_WORLD
     for (i=0;i<30000;i+=1000) {
-      sprintf(buf, "world/mobs.%d", i);
+      SPRINTF(buf, "world/mobs.%d", i);
       fl = fopen(buf, "r");
       if(!fl) {
 	log_msg("Unable to load scratch zone file for update.");
@@ -1938,7 +1938,7 @@ void reset_zone(int zone)
     s = zone_table[zone].name;
     d = (zone ? (zone_table[zone - 1].top + 1) : 0);
     e = zone_table[zone].top;
-    sprintf(buf, "Run time initialization of zone %s, rooms (%d-%d)",
+    SPRINTF(buf, "Run time initialization of zone %s, rooms (%d-%d)",
 	    s, d, e);
     log_msg(buf);
 
@@ -2026,7 +2026,7 @@ void reset_zone(int zone)
 		last_cmd = 0;
 	    }
 	  } else if ((obj = read_object(ZCMD.arg1, REAL)) != NULL) {
-	    sprintf(buf, "Error finding room #%d", ZCMD.arg3);
+	    SPRINTF(buf, "Error finding room #%d", ZCMD.arg3);
 	    log_msg(buf);
 	    last_cmd = 1;
 	  }  else {
@@ -2081,7 +2081,7 @@ void reset_zone(int zone)
 	  if (!mob->equipment[ZCMD.arg3]) {
 	    equip_char(mob, obj, ZCMD.arg3);
 	  } else {
-	    sprintf(buf, "eq error - zone %d, cmd %d, item %d, mob %d, loc %d\n", zone, cmd_no, 
+	    SPRINTF(buf, "eq error - zone %d, cmd %d, item %d, mob %d, loc %d\n", zone, cmd_no, 
 		    obj_index[ZCMD.arg1].virtual, mob_index[mob->nr].virtual, ZCMD.arg3);
 	    log_sev(buf, 6);
 	  }
@@ -2117,7 +2117,7 @@ void reset_zone(int zone)
 	break;
 	
       default:
-	sprintf(buf, "Undefd cmd [%c] in reset table; zone %d cmd %d.",
+	SPRINTF(buf, "Undefd cmd [%c] in reset table; zone %d cmd %d.",
 		ZCMD.command,zone, cmd_no);
 	log_msg(buf);
 	break;
@@ -2800,11 +2800,11 @@ void reset_char(struct char_data *ch)
   }
   
   if (GET_BANK(ch) > GetMaxLevel(ch)*100000) {
-    sprintf(buf, "%s has %d coins in bank.", GET_NAME(ch), GET_BANK(ch));
+    SPRINTF(buf, "%s has %d coins in bank.", GET_NAME(ch), GET_BANK(ch));
     log_msg(buf);
   }
   if (GET_GOLD(ch) > GetMaxLevel(ch)*100000) {
-    sprintf(buf, "%s has %d coins.", GET_NAME(ch), GET_GOLD(ch));
+    SPRINTF(buf, "%s has %d coins.", GET_NAME(ch), GET_GOLD(ch));
     log_msg(buf);
   }
 
@@ -3153,7 +3153,7 @@ void reboot_text(struct char_data *ch, char * UNUSED(arg), int UNUSED(cmd)) {
     for(i = 0; i < top_of_scripts; i++) {
       if(script_data[i].virtual == mob_index[p->nr].virtual) {
 	SET_BIT(p->specials.act, ACT_SCRIPT);
-	sprintf(buffer, "Setting SCRIPT bit for mobile %s, file %s.", GET_NAME(p), script_data[i].filename);
+	SPRINTF(buffer, "Setting SCRIPT bit for mobile %s, file %s.", GET_NAME(p), script_data[i].filename);
 	log_msg(buffer);
 	p->script = i;
 	break;
@@ -3214,15 +3214,15 @@ void InitScripts()
       char garbage[4];
       strncpy(garbage, buf, 3);
       garbage[3] = '\0';
-      sprintf(buf,"%s read in, garbage.", garbage);
+      SPRINTF(buf,"%s read in, garbage.", garbage);
       log_msg(buf);
     }
 
     sscanf(buf, "%s %d", buf2, &i);
 
-    sprintf(buf, "scripts/%s", buf2);
+    SPRINTF(buf, "scripts/%s", buf2);
     if(!(f2 = fopen(buf, "r"))) {
-       sprintf(buf, "Unable to open script \"%s\" for reading.", buf2);
+       SPRINTF(buf, "Unable to open script \"%s\" for reading.", buf2);
        log_msg(buf);
      }
 
@@ -3255,7 +3255,7 @@ void InitScripts()
        script_data[top_of_scripts].virtual = i;
        script_data[top_of_scripts].filename = (char *) malloc((strlen(buf2) + 1) * sizeof(char));
        strcpy(script_data[top_of_scripts].filename, buf2);
-       sprintf(buf, "Script %s assigned to mobile %d.", buf2, i);
+       SPRINTF(buf, "Script %s assigned to mobile %d.", buf2, i);
        log_msg(buf);
        top_of_scripts++;
        fclose(f2);
@@ -3263,9 +3263,9 @@ void InitScripts()
   }
 
   if(top_of_scripts)
-     sprintf(buf, "%d scripts assigned.", top_of_scripts);
+     SPRINTF(buf, "%d scripts assigned.", top_of_scripts);
   else
-     sprintf(buf, "No scripts found to assign.");
+     SPRINTF(buf, "No scripts found to assign.");
   log_msg(buf);
 
   fclose(f1);
@@ -3316,7 +3316,7 @@ void SaveTheWorld()
 
   if (ctl == 30000) ctl = 0;
     
-  sprintf(buf, "world/mobs.%d", ctl);
+  SPRINTF(buf, "world/mobs.%d", ctl);
   fp = (FILE *)fopen(buf, "w");  /* append */
   
   if (!fp) {
@@ -3497,7 +3497,7 @@ void ReadTextZone( FILE *fl)
 	      last_cmd = 0;
 	    }
 	  } else if ((obj = read_object(i, VIRTUAL)) != NULL) {
-	    sprintf(buf, "Error finding room #%d", k);
+	    SPRINTF(buf, "Error finding room #%d", k);
 	    log_msg(buf);
 	    last_cmd = 1;
 	  }  else {
@@ -3557,7 +3557,7 @@ void ReadTextZone( FILE *fl)
 	  if (!mob->equipment[k]) {
 	    equip_char(mob, obj, k);
 	  } else {
-	    sprintf(buf,"eq error - zone %d, cmd %d, item %d, mob %d, loc %d", 
+	    SPRINTF(buf,"eq error - zone %d, cmd %d, item %d, mob %d, loc %d", 
 		    zone, 1, obj_index[i].virtual, 
 		    mob_index[mob->nr].virtual, k);
 	    log_sev(buf, 6);
@@ -3625,13 +3625,13 @@ int VerifyMob(struct char_data *ch)
   /* check to see that the mob falls within certain parameters */
 
   if (ch->specials.damnodice < 0) {
-    sprintf(buf, "%s's number of damage dice is negative\n",
+    SPRINTF(buf, "%s's number of damage dice is negative\n",
             ch->player.name);
     log_sev(buf, 6);
   }
 
   if (ch->specials.damsizedice < 0) {
-    sprintf(buf, "%s's size of damage dice is negative\n",
+    SPRINTF(buf, "%s's size of damage dice is negative\n",
             ch->player.name);
     log_sev(buf, 6);
   }
@@ -3672,7 +3672,7 @@ void clean_playerfile()
        num_processed++;
        grunt.AXE = FALSE;
        if(!str_cmp(grunt.dummy.name,"111111")) {
-	 sprintf(buf,"%s was deleted (111111 name hopefully).",
+	 SPRINTF(buf,"%s was deleted (111111 name hopefully).",
 		 grunt.dummy.name);
 	 log_msg(buf);
 	 ones++;
@@ -3694,14 +3694,14 @@ void clean_playerfile()
            if(timeH-grunt.dummy.last_logon > (long) j*(SECS_PER_REAL_DAY*30)){
 	     num_deleted++;
              grunt.AXE = TRUE;	
-	     sprintf(buf,"%s deleted after %d months of inactivity.",
+	     SPRINTF(buf,"%s deleted after %d months of inactivity.",
 		     grunt.dummy.name,j);
 	     log_msg(buf);
            }
          } else if(max > LOW_IMMORTAL) {
            if(timeH-grunt.dummy.last_logon > (long) SECS_PER_REAL_DAY*30) {
 	     num_demoted++;
-             sprintf(buf,"%s demoted from %d to %d due to inactivity.",
+             SPRINTF(buf,"%s demoted from %d to %d due to inactivity.",
                      grunt.dummy.name,max,max-1);
 	     log_msg(buf);
              grunt.dummy.last_logon = timeH; /* so it doesn't happen twice */
@@ -3718,17 +3718,17 @@ void clean_playerfile()
      }
   }
 
-  sprintf(buf,"-- %d characters were processed.", num_processed);
+  SPRINTF(buf,"-- %d characters were processed.", num_processed);
   log_msg(buf);
-  sprintf(buf,"-- %d characters were deleted.  ", num_deleted);
+  SPRINTF(buf,"-- %d characters were deleted.  ", num_deleted);
   log_msg(buf);
-  sprintf(buf,"-- %d of these were allread deleted. (11111s)", ones);
+  SPRINTF(buf,"-- %d of these were allread deleted. (11111s)", ones);
   log_msg(buf);
-  sprintf(buf,"-- %d gods were demoted due to inactivity.", num_demoted);
+  SPRINTF(buf,"-- %d gods were demoted due to inactivity.", num_demoted);
   log_msg(buf);
-  sprintf(buf,"mv %s %s.bak", PLAYER_FILE, PLAYER_FILE);
+  SPRINTF(buf,"mv %s %s.bak", PLAYER_FILE, PLAYER_FILE);
   system(buf);
-  sprintf(buf,"mv temp %s", PLAYER_FILE);
+  SPRINTF(buf,"mv temp %s", PLAYER_FILE);
   system(buf);
   log_msg("Cleaning done.");
 
@@ -3746,7 +3746,7 @@ void ensure_file_exists(const char *path) {
       char *buf;
       const char *fmt = "Creating empty file \"%s\"";
       buf = (char *)malloc(strlen(path) + strlen(fmt) - 1);
-      sprintf(buf, fmt, path);
+      SPRINTF(buf, fmt, path);
       log_msg(buf);
       free(buf);
     }
@@ -3754,7 +3754,7 @@ void ensure_file_exists(const char *path) {
       char *buf;
       const char *fmt = "ensure_file_exists(%s)(open)";
       buf = (char *)malloc(strlen(path) + strlen(fmt) - 1);
-      sprintf(buf, fmt, path);
+      SPRINTF(buf, fmt, path);
       perror(buf);
       free(buf);
       exit(-1);
@@ -3764,7 +3764,7 @@ void ensure_file_exists(const char *path) {
     char *buf;
     const char *fmt = "ensure_file_exists(%s)(stat)";
     buf = (char *)malloc(strlen(path) + strlen(fmt) - 1);
-    sprintf(buf, fmt, path);
+    SPRINTF(buf, fmt, path);
     perror(buf);
     free(buf);
     exit(-1);

--- a/src/fight.c
+++ b/src/fight.c
@@ -269,7 +269,7 @@ void stop_fighting(struct char_data *ch)
   
   if (!ch->specials.fighting) {
     char buf[300];
-    sprintf(buf, "%s not fighting at invocation of stop_fighting",
+    SPRINTF(buf, "%s not fighting at invocation of stop_fighting",
 	    GET_NAME(ch));
     return;
   }
@@ -351,14 +351,14 @@ void make_corpse(struct char_data *ch)
   corpse->in_room = NOWHERE;
   
   if (!IS_NPC(ch) || (!IsUndead(ch))) {
-    sprintf(buf, "corpse %s",ch->player.name);
+    SPRINTF(buf, "corpse %s",ch->player.name);
     corpse->name = strdup(buf);
     
-    sprintf(buf, "The corpse of %s is lying here.", 
+    SPRINTF(buf, "The corpse of %s is lying here.", 
 	    (IS_NPC(ch) ? ch->player.short_descr : GET_NAME(ch)));
     corpse->description = strdup(buf);
     
-    sprintf(buf, "the corpse of %s",
+    SPRINTF(buf, "the corpse of %s",
 	    (IS_NPC(ch) ? ch->player.short_descr : GET_NAME(ch)));
     corpse->short_description = strdup(buf);
     
@@ -602,7 +602,7 @@ void die(struct char_data *ch)
                      ch);
         send_to_char("Your next death will result in the loss of a level,\n\r",
                      ch);
-        sprintf(buf,"unless you get at least %d more exp points.\n\r",
+        SPRINTF(buf,"unless you get at least %d more exp points.\n\r",
                 (titles[i][(int)GET_LEVEL(ch, i)].exp/fraction) - GET_EXP(ch));
         send_to_char(buf,ch);
       }
@@ -696,7 +696,7 @@ void group_gain(struct char_data *ch, struct char_data *victim)
 
       RatioExp(k, victim, total);
 
-      sprintf(buf,"You receive your share of %d experience.", total);
+      SPRINTF(buf,"You receive your share of %d experience.", total);
       act(buf, FALSE, k, 0, 0, TO_CHAR);
       gain_exp(k,total);
       change_alignment(k, victim);
@@ -717,7 +717,7 @@ void group_gain(struct char_data *ch, struct char_data *victim)
 
 	if (IS_PC(f->follower)) {
 	  total = RatioExp(f->follower, victim, total);
-	  sprintf(buf,"You receive your share of %d experience.", total);
+	  SPRINTF(buf,"You receive your share of %d experience.", total);
 	  act(buf, FALSE, f->follower,0,0,TO_CHAR);
 	  gain_exp(f->follower,  total);
 	
@@ -727,14 +727,14 @@ void group_gain(struct char_data *ch, struct char_data *victim)
 	    total = RatioExp(f->follower->master, victim, total);
 	    if (f->follower->master->in_room ==
 		f->follower->in_room) {
-	      sprintf(buf,"You receive $N's share of %d experience.", total);
+	      SPRINTF(buf,"You receive $N's share of %d experience.", total);
 	      act(buf, FALSE, f->follower->master,0,f->follower,TO_CHAR);
 	      gain_exp(f->follower->master,  total);
 	      change_alignment(f->follower, victim);
 	    }
 	  } else {
 	    total = RatioExp(f->follower, victim, total);
-	    sprintf(buf,"You receive your share of %d experience.", total);
+	    SPRINTF(buf,"You receive your share of %d experience.", total);
 	    act(buf, FALSE, f->follower,0,0,TO_CHAR);
 	    gain_exp(f->follower,  total);
 	    
@@ -895,7 +895,7 @@ int DamCheckDeny(struct char_data *ch, struct char_data *victim, int type)
   rp = real_roomp(ch->in_room);
   if (rp && (rp->room_flags&PEACEFUL) && type!=SPELL_POISON && 
       type!=SPELL_HEAT_STUFF) {
-    sprintf(buf, "damage(,,,%d) called in PEACEFUL room", type);
+    SPRINTF(buf, "damage(,,,%d) called in PEACEFUL room", type);
     log_msg(buf);
     return(TRUE); /* true, they are denied from fighting */
   }
@@ -1216,7 +1216,7 @@ int DamageEpilog(struct char_data *ch, struct char_data *victim)
           mula = GET_GOLD(victim);
           GET_GOLD(victim)=0;
           GET_GOLD(ch) += mula;
-          sprintf(buf, "You loot %d gold from the body of %s.\n\r", mula, victim->player.short_descr);
+          SPRINTF(buf, "You loot %d gold from the body of %s.\n\r", mula, victim->player.short_descr);
           send_to_char(buf, ch);
           gotsome = TRUE;
         }
@@ -1227,7 +1227,7 @@ int DamageEpilog(struct char_data *ch, struct char_data *victim)
       if (IS_AFFECTED(ch, AFF_GROUP)) {
 	group_gain(ch, victim);
         if((ch->specials.split) && gotsome) {
-          sprintf(buf, "split %d", mula);
+          SPRINTF(buf, "split %d", mula);
           command_interpreter(ch, buf);
         }
       } else {
@@ -1245,25 +1245,25 @@ int DamageEpilog(struct char_data *ch, struct char_data *victim)
     if (IS_PC(victim)) {
       if (victim->in_room > -1) {
 	if (IS_NPC(ch)&&!IS_SET(ch->specials.act, ACT_POLYSELF)) {
-	   sprintf(buf, "%s killed by %s at %s",
+	   SPRINTF(buf, "%s killed by %s at %s",
 		GET_NAME(victim), ch->player.short_descr,
 		(real_roomp(victim->in_room))->name);
 
 	} else {
 	   if ((IS_GOOD(ch) && !IS_EVIL(victim))  ||
 	       (IS_EVIL(ch) && IS_NEUTRAL(victim))) {
-	     sprintf(buf, "%s killed by %s at %s -- <Player kill, Illegal>",
+	     SPRINTF(buf, "%s killed by %s at %s -- <Player kill, Illegal>",
 		     GET_NAME(victim), ch->player.name, 
 		     (real_roomp(victim->in_room))->name);
 	   } else {
-	     sprintf(buf, "%s killed by %s at %s",
+	     SPRINTF(buf, "%s killed by %s at %s",
 		     GET_NAME(victim), GET_NAME(ch),
 		     (real_roomp(victim->in_room))->name);
 	   }
 
 	}
       } else {
-	sprintf(buf, "%s killed by %s at Nowhere.",
+	SPRINTF(buf, "%s killed by %s at Nowhere.",
 		GET_NAME(victim),
 		(IS_NPC(ch) ? ch->player.short_descr : GET_NAME(ch)));
       }
@@ -1277,7 +1277,7 @@ int DamageEpilog(struct char_data *ch, struct char_data *victim)
       if (IS_SET(victim->specials.act, ACT_SPEC)) {
 	if (mob_index[victim->nr].func) {
 	  if (mob_index[victim->nr].func == shop_keeper) {
-	    sprintf(buf, "%s (shopkeeper) killed by %s\n",
+	    SPRINTF(buf, "%s (shopkeeper) killed by %s\n",
 		    GET_NAME(victim), GET_NAME(ch));
 	    log_sev(buf, 6);
 	  }
@@ -1369,7 +1369,7 @@ void AreaDamage(struct char_data *ch, int dam, int attacktype,
 	if(i == -1)
 	  MakeScrap(ch, obj);
 	else if(i != 0) {
-	  sprintf(buf, "%s is %s.\n\r",obj->short_description,
+	  SPRINTF(buf, "%s is %s.\n\r",obj->short_description,
 		  ItemDamType[dam_type-1]);
 	  send_to_room(buf, ch->in_room);
 	  if (DamageItem(obj, i)) {
@@ -1466,7 +1466,7 @@ int damage(struct char_data *ch, struct char_data *victim,
       attacktype!=SPELL_POISON /* poison is allowed */
       ) {
     char	buf[MAX_INPUT_LENGTH];
-    sprintf(buf, "damage(,,,%d) called in PEACEFUL room", attacktype);
+    SPRINTF(buf, "damage(,,,%d) called in PEACEFUL room", attacktype);
     log_msg(buf);
     return;
   }
@@ -1666,12 +1666,12 @@ int damage(struct char_data *ch, struct char_data *victim,
       }
     if (!IS_NPC(victim)) {
       if (victim->in_room > -1) {
-	sprintf(buf, "%s killed by %s at %s",
+	SPRINTF(buf, "%s killed by %s at %s",
 		GET_NAME(victim),
 		(IS_NPC(ch) ? ch->player.short_descr : GET_NAME(ch)),
 		(real_roomp(victim->in_room))->name);
       } else {
-	sprintf(buf, "%s killed by %s at Nowhere.",
+	SPRINTF(buf, "%s killed by %s at Nowhere.",
 		GET_NAME(victim),
 		(IS_NPC(ch) ? ch->player.short_descr : GET_NAME(ch)));
       }
@@ -1779,14 +1779,14 @@ int HitCheckDeny(struct char_data *ch, struct char_data *victim) {
 
   rp = real_roomp(ch->in_room);
   if (rp && rp->room_flags&PEACEFUL && PeacefulWorks) {
-    sprintf(buf, "hit() called in PEACEFUL room");
+    SPRINTF(buf, "hit() called in PEACEFUL room");
     log_msg(buf);
     stop_fighting(ch);
     return(TRUE);
   }
   
   if (ch->in_room != victim->in_room) {
-    sprintf(buf, "NOT in same room when fighting : %s, %s", ch->player.name, victim->player.name);
+    SPRINTF(buf, "NOT in same room when fighting : %s, %s", ch->player.name, victim->player.name);
     log_msg(buf);
     stop_fighting(ch);
     return(TRUE);
@@ -2279,7 +2279,7 @@ int GetBackstabMult(struct char_data *ch, struct char_data *v)
   }
 
   if(!our_skill) {
-    sprintf(buf, "Warning, race %d was unaccounted for in GetBackstabMult()",
+    SPRINTF(buf, "Warning, race %d was unaccounted for in GetBackstabMult()",
 	    GET_RACE(v));
     log_msg(buf);
     return(mult);
@@ -2320,7 +2320,7 @@ void HitVictim(struct char_data *ch, struct char_data *v, int dam,
       int tmp;
 
       tmp = GetBackstabMult(ch, v);
-      sprintf(buf, "BS multiplier for %dth level char is %d.", GetMaxLevel(ch),
+      SPRINTF(buf, "BS multiplier for %dth level char is %d.", GetMaxLevel(ch),
 	      tmp);
       log_msg(buf);
       dam *= tmp;
@@ -2446,7 +2446,7 @@ void perform_violence() {
     rp = real_roomp(ch->in_room);
     if (rp && rp->room_flags&PEACEFUL) {
       char	buf[MAX_INPUT_LENGTH];
-      sprintf(buf,"perform_violence() found %s fighting in a PEACEFUL room.",
+      SPRINTF(buf,"perform_violence() found %s fighting in a PEACEFUL room.",
 	      ch->player.name);
       stop_fighting(ch);
       log_msg(buf);
@@ -2908,7 +2908,7 @@ void BreakLifeSaverObj( struct char_data *ch)
          *  break the object.
          */
 
-	 sprintf(buf,"%s shatters with a blinding flash of light!\n\r", 
+	 SPRINTF(buf,"%s shatters with a blinding flash of light!\n\r", 
 		 ch->equipment[found]->name);
 	 send_to_char(buf, ch);
 	 if ((o = unequip_char(ch, found)) != NULL) {
@@ -2929,7 +2929,7 @@ int BrittleCheck(struct char_data *ch, int dam)
   if (ch->equipment[WIELD]) {
     if (IS_OBJ_STAT(ch->equipment[WIELD], ITEM_BRITTLE)) {
        if ((obj = unequip_char(ch,WIELD))!=NULL) {
-	 sprintf(buf, "%s shatters.\n\r", obj->short_description);
+	 SPRINTF(buf, "%s shatters.\n\r", obj->short_description);
 	 send_to_char(buf, ch);
 	 MakeScrap(ch, obj);
          return(TRUE);
@@ -3049,7 +3049,7 @@ int DamageOneItem( struct char_data *ch, int dam_type, struct obj_data *obj)
   if (num == -1) {  /* destroy object*/
     return(TRUE);
   } else if (num != 0) {
-    sprintf(buf, "%s is %s.\n\r",obj->short_description, 
+    SPRINTF(buf, "%s is %s.\n\r",obj->short_description, 
 	    ItemDamType[dam_type-1]);
     send_to_char(buf,ch);
     if (DamageItem(obj, num)) {
@@ -3085,7 +3085,7 @@ void MakeScrap( struct char_data *ch, struct obj_data *obj)
     
     t = read_object(30, VIRTUAL);
     
-    sprintf(buf, "Scraps from %s lie in a pile here.", 
+    SPRINTF(buf, "Scraps from %s lie in a pile here.", 
 	    obj->short_description);
     
     free(t->description);

--- a/src/handler.c
+++ b/src/handler.c
@@ -620,7 +620,7 @@ void char_from_room(struct char_data *ch)
   
   rp = real_roomp(ch->in_room);
   if (rp==NULL) {
-    sprintf(buf, "ERROR: char_from_room: %s was not in a valid room (%d)",
+    SPRINTF(buf, "ERROR: char_from_room: %s was not in a valid room (%d)",
 	    (!IS_NPC(ch) ? (ch)->player.name : (ch)->player.short_descr),
 	    ch->in_room);
     log_msg(buf);
@@ -636,7 +636,7 @@ void char_from_room(struct char_data *ch)
     if (i)
       i->next_in_room = ch->next_in_room;
     else {
-      sprintf(buf, "SHIT, %s was not in people list of his room %d!",
+      SPRINTF(buf, "SHIT, %s was not in people list of his room %d!",
 	      (!IS_NPC(ch) ? (ch)->player.name : (ch)->player.short_descr),
 	      ch->in_room);
       log_msg(buf);
@@ -1241,17 +1241,17 @@ void obj_from_obj(struct obj_data *obj)
   char buf[100];
 
   if (obj->carried_by) {
-    sprintf(buf, "%s carried by %s in obj_from_obj\n", obj->name,
+    SPRINTF(buf, "%s carried by %s in obj_from_obj\n", obj->name,
 	    obj->carried_by->player.name);
     log_msg(buf);
   }
   if (obj->equipped_by) {
-    sprintf(buf, "%s equipped by %s in obj_from_obj\n", obj->name,
+    SPRINTF(buf, "%s equipped by %s in obj_from_obj\n", obj->name,
 	    obj->equipped_by->player.name);
     log_msg(buf);
   }
   if (obj->in_room != NOWHERE) {
-    sprintf(buf, "%s in room %d in obj_from_obj\n", obj->name,
+    SPRINTF(buf, "%s in room %d in obj_from_obj\n", obj->name,
 	    obj->in_room);
     log_msg(buf);
   }
@@ -1818,19 +1818,19 @@ struct obj_data *create_money( int amount )
     
     new_descr->keyword = strdup("coins gold");
     if(amount<10) {
-      sprintf(buf,"There are %d coins.",amount);
+      SPRINTF(buf,"There are %d coins.",amount);
       new_descr->description = strdup(buf);
     } 
     else if (amount<100) {
-      sprintf(buf,"There is about %d coins.",10*(amount/10));
+      SPRINTF(buf,"There is about %d coins.",10*(amount/10));
       new_descr->description = strdup(buf);
     }
     else if (amount<1000) {
-      sprintf(buf,"It looks like something round %d coins.",100*(amount/100));
+      SPRINTF(buf,"It looks like something round %d coins.",100*(amount/100));
       new_descr->description = strdup(buf);
     }
     else if (amount<100000) {
-      sprintf(buf,"You guess there is %d coins.",1000*((amount/1000)+ number(0,(amount/1000))));
+      SPRINTF(buf,"You guess there is %d coins.",1000*((amount/1000)+ number(0,(amount/1000))));
       new_descr->description = strdup(buf);
     }
     else 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -252,19 +252,19 @@ void command_interpreter(struct char_data *ch, char *argument)
 	  return;  
 
           if(n->log) {
-            sprintf(buf,"%s:%s",ch->player.name, argument);
+            SPRINTF(buf,"%s:%s",ch->player.name, argument);
             slog(buf);
 	  }
 	  if ((GetMaxLevel(ch)>=LOW_IMMORTAL)&&(GetMaxLevel(ch)<60)) {
-	    sprintf(buf,"%s:%s",ch->player.name,argument);
+	    SPRINTF(buf,"%s:%s",ch->player.name,argument);
 	    slog(buf);
 	  }
            if(IS_AFFECTED2(ch, AFF2_LOG_ME)) {
-             sprintf(buf,"%s:%s", ch->player.name, argument);
+             SPRINTF(buf,"%s:%s", ch->player.name, argument);
              slog(buf);
 	   }
 	  if (GET_GOLD(ch) > 2000000) {
-	    sprintf(buf,"%s:%s",fname(ch->player.name),argument);
+	    SPRINTF(buf,"%s:%s",fname(ch->player.name),argument);
 	    slog(buf);
 	  }
 	
@@ -1018,14 +1018,14 @@ void nanny(struct descriptor_data *d, char *arg)
 	    do_help(d->character,help_thing,0);
 	    SEND_TO_Q("Level limits (NVC = Not a Valid Class):\n\r",d);
 	    if(CheckValidClass(d, CLASS_MAGIC_USER)) {
-	      sprintf(buf,"Mage: %d  ",
+	      SPRINTF(buf,"Mage: %d  ",
 		      RacialMax[RaceList[choice].race_num][0]);
 	      SEND_TO_Q(buf,d);
 	    } else 
 	      SEND_TO_Q("Mage: NVC  ",d);
 	    
 	    if(CheckValidClass(d, CLASS_CLERIC)) {
-	      sprintf(buf,"Cleric: %d  ",
+	      SPRINTF(buf,"Cleric: %d  ",
 		      RacialMax[RaceList[choice].race_num][1]);
 	      SEND_TO_Q(buf,d);
 	    } else 
@@ -1033,7 +1033,7 @@ void nanny(struct descriptor_data *d, char *arg)
 
 	    
 	    if(CheckValidClass(d, CLASS_WARRIOR)) {
-	      sprintf(buf,"Warrior: %d  ",
+	      SPRINTF(buf,"Warrior: %d  ",
 		      RacialMax[RaceList[choice].race_num][2]);
 	      SEND_TO_Q(buf,d);
 	    } else 
@@ -1041,14 +1041,14 @@ void nanny(struct descriptor_data *d, char *arg)
 
 	    
 	    if(CheckValidClass(d, CLASS_THIEF)) {
-	      sprintf(buf,"Thief: %d  ",
+	      SPRINTF(buf,"Thief: %d  ",
 		      RacialMax[RaceList[choice].race_num][3]);
 	      SEND_TO_Q(buf,d);
 	    } else 
 	      SEND_TO_Q("Thief: NVC  ",d);
 	    
 	    if(CheckValidClass(d, CLASS_DRUID)) {
-	      sprintf(buf,"Druid: %d  ",
+	      SPRINTF(buf,"Druid: %d  ",
 		      RacialMax[RaceList[choice].race_num][4]);
 	      SEND_TO_Q(buf,d);
 	    } else 
@@ -1056,7 +1056,7 @@ void nanny(struct descriptor_data *d, char *arg)
 
 	    
 	    if(CheckValidClass(d, CLASS_MONK)) {
-	      sprintf(buf,"Monk: %d  ",
+	      SPRINTF(buf,"Monk: %d  ",
 		      RacialMax[RaceList[choice].race_num][0]);
 	      SEND_TO_Q(buf,d);
 	    } else 
@@ -1182,7 +1182,7 @@ void nanny(struct descriptor_data *d, char *arg)
 	/*
 	  if (tmp_store.max_corpse > 3) {
 	  SEND_TO_Q("Too many corpses in game, can not connect\n\r", d);
-	  sprintf(buf, "%s: too many corpses.",tmp_name);
+	  SPRINTF(buf, "%s: too many corpses.",tmp_name);
 	  log_msg(buf);
 	  STATE(d) = CON_WIZLOCK;
 	  break;
@@ -1214,12 +1214,12 @@ void nanny(struct descriptor_data *d, char *arg)
 	  CREATE(GET_NAME(d->character), char, 
 		 strlen(tmp_name) + 1);
 	  strcpy(GET_NAME(d->character), CAP(tmp_name));
-	  sprintf(buf, "Did I get that right, %s (Y/N)? ",
+	  SPRINTF(buf, "Did I get that right, %s (Y/N)? ",
 		  tmp_name);
 	  SEND_TO_Q(buf, d);
 	  STATE(d) = CON_NMECNF;
 	} else {
-	  sprintf(buf, "Sorry, no new characters at this time\n\r");
+	  SPRINTF(buf, "Sorry, no new characters at this time\n\r");
 	  SEND_TO_Q(buf,d);
 	  STATE(d) = CON_WIZLOCK;
 	}
@@ -1234,7 +1234,7 @@ void nanny(struct descriptor_data *d, char *arg)
     if (*arg == 'y' || *arg == 'Y')	{
       SEND_TO_Q("New character.\n\r", d);
       
-      sprintf(buf, 
+      SPRINTF(buf, 
 	      "Give me a password for %s: ",
 	      GET_NAME(d->character));
       
@@ -1307,14 +1307,14 @@ void nanny(struct descriptor_data *d, char *arg)
 	  STATE(d) = CON_PLYNG;
 	  
 	  act("$n has reconnected.", TRUE, tmp_ch, 0, 0, TO_ROOM);
-	  sprintf(buf, "%s[%s] has reconnected.",
+	  SPRINTF(buf, "%s[%s] has reconnected.",
 		  GET_NAME(d->character), d->host);
 	  log_msg(buf);
 	  return;
 	}
       
       
-      sprintf(buf, "%s[%s] has connected.", GET_NAME(d->character),
+      SPRINTF(buf, "%s[%s] has connected.", GET_NAME(d->character),
 	      d->host);
       log_msg(buf);
       SEND_TO_Q(motd, d);
@@ -1444,7 +1444,7 @@ void nanny(struct descriptor_data *d, char *arg)
 	break;
       } else {
 	SEND_TO_Q(VT_HOMECLR,d);
-	sprintf(buf,"Hey, what kinda statistic does an %c represent?\n\r",
+	SPRINTF(buf,"Hey, what kinda statistic does an %c represent?\n\r",
 		*arg);
 	SEND_TO_Q(STATQ_MESSG,d);
 	STATE(d) = CON_STAT_LIST;
@@ -1629,7 +1629,7 @@ void nanny(struct descriptor_data *d, char *arg)
       SEND_TO_Q("***PRESS ENTER**", d);
 #else
       if (STATE(d) != CON_QCLASS) {
-	sprintf(buf, "%s [%s] new player.", GET_NAME(d->character), d->host);
+	SPRINTF(buf, "%s [%s] new player.", GET_NAME(d->character), d->host);
 	log_msg(buf);
 	/*
 	 ** now that classes are set, initialize
@@ -1662,7 +1662,7 @@ void nanny(struct descriptor_data *d, char *arg)
        SEND_TO_Q("\n\r\n*** PRESS RETURN: ", d);
        STATE(d) = CON_RMOTD;            
      } else if (d->character->generic >= NEWBIE_REQUEST) {
-       sprintf(buf, "%s [%s] new player.", GET_NAME(d->character), d->host);
+       SPRINTF(buf, "%s [%s] new player.", GET_NAME(d->character), d->host);
        log_sev(buf, 7);
        if (!strncmp(d->host,"128.197.152",11))
            d->character->generic=1;
@@ -1673,7 +1673,7 @@ void nanny(struct descriptor_data *d, char *arg)
 	 d->character->generic=1;	 
        } else {
 	 if (top_of_p_table > 0) {
-	   sprintf(buf,"type Auth[orize] %s to allow into game.", GET_NAME(d->character));
+	   SPRINTF(buf,"type Auth[orize] %s to allow into game.", GET_NAME(d->character));
 	   log_sev(buf, 6);
 	   log_sev("type 'Help Authorize' for other commands", 2);
 	 } else {
@@ -1685,7 +1685,7 @@ void nanny(struct descriptor_data *d, char *arg)
        **  enough for gods.  now player is told to shut up.
        */
        d->character->generic--;   /* NEWBIE_START == 3 == 3 chances */
-       sprintf(buf, "Please wait. You have %d requests remaining.\n\r", 
+       SPRINTF(buf, "Please wait. You have %d requests remaining.\n\r", 
 	       d->character->generic);
        SEND_TO_Q(buf, d);
        if (d->character->generic == 0) {
@@ -1716,7 +1716,7 @@ void nanny(struct descriptor_data *d, char *arg)
     STATE(d) = CON_SLCT;
     if (WizLock) {
       if (GetMaxLevel(d->character) < LOW_IMMORTAL) {
-	sprintf(buf, "Sorry, the game is locked up for repair\n\r");
+	SPRINTF(buf, "Sorry, the game is locked up for repair\n\r");
 	SEND_TO_Q(buf,d);
 	STATE(d) = CON_WIZLOCK;
       }
@@ -1730,7 +1730,7 @@ void nanny(struct descriptor_data *d, char *arg)
     STATE(d) = CON_SLCT;
     if (WizLock) {
       if (GetMaxLevel(d->character) < LOW_IMMORTAL) {
-	sprintf(buf, "Sorry, the game is locked up for repair\n\r");
+	SPRINTF(buf, "Sorry, the game is locked up for repair\n\r");
 	SEND_TO_Q(buf,d);
 	STATE(d) = CON_WIZLOCK;
       }
@@ -1752,7 +1752,7 @@ void nanny(struct descriptor_data *d, char *arg)
       case '1':
 
         reset_char(d->character);
-        sprintf(buf, "Loading %s's equipment", d->character->player.name);
+        SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
         log_msg(buf);
         load_char_objs(d->character);
         save_char(d->character, AUTO_RENT);
@@ -1780,7 +1780,7 @@ void nanny(struct descriptor_data *d, char *arg)
       case '2':
 
         reset_char(d->character);
-        sprintf(buf, "Loading %s's equipment", d->character->player.name);
+        SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
         log_msg(buf);
         load_char_objs(d->character);
         save_char(d->character, AUTO_RENT);
@@ -1808,7 +1808,7 @@ void nanny(struct descriptor_data *d, char *arg)
 	if (GetMaxLevel(d->character) > 5) {
 
           reset_char(d->character);
-          sprintf(buf, "Loading %s's equipment", d->character->player.name);
+          SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
           log_msg(buf);
           load_char_objs(d->character);
           save_char(d->character, AUTO_RENT);
@@ -1841,7 +1841,7 @@ void nanny(struct descriptor_data *d, char *arg)
 	if (GetMaxLevel(d->character) > 5) {
 
           reset_char(d->character);
-          sprintf(buf, "Loading %s's equipment", d->character->player.name);
+          SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
           log_msg(buf);
           load_char_objs(d->character);
           save_char(d->character, AUTO_RENT);
@@ -1874,7 +1874,7 @@ void nanny(struct descriptor_data *d, char *arg)
 	if (GetMaxLevel(d->character) > 5) {
 
           reset_char(d->character);
-          sprintf(buf, "Loading %s's equipment", d->character->player.name);
+          SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
           log_msg(buf);
           load_char_objs(d->character);
           save_char(d->character, AUTO_RENT);
@@ -1921,7 +1921,7 @@ void nanny(struct descriptor_data *d, char *arg)
       
     case '1':
       reset_char(d->character);
-      sprintf(buf, "Loading %s's equipment", d->character->player.name);
+      SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
       log_msg(buf);
       load_char_objs(d->character);
       save_char(d->character, AUTO_RENT);
@@ -2048,7 +2048,7 @@ void nanny(struct descriptor_data *d, char *arg)
 
       /* read in the char, change the name, write back */
       fread(&ch_st, sizeof(struct char_file_u), 1, char_file);
-      sprintf(ch_st.name,"111111");
+      SPRINTF(ch_st.name,"111111");
       fseek(char_file, (long) (player_table[i].nr *
 			       sizeof(struct char_file_u)), 0);
       fwrite(&ch_st, sizeof(struct char_file_u), 1, char_file);
@@ -2187,7 +2187,7 @@ void DisplayRaceClasses(struct descriptor_data *d)
     if(CheckValidClass(d,classes[i])) {
       if(bart)
 	SEND_TO_Q(", ",d);
-      sprintf(buf,"%s [%d]", class_selections[i], 
+      SPRINTF(buf,"%s [%d]", class_selections[i], 
 	      RacialMax[GET_RACE(d->character)][i]);
       SEND_TO_Q(buf,d);
       bart = TRUE;
@@ -2206,7 +2206,7 @@ void DisplayRaces(struct descriptor_data *d)
 
   SEND_TO_Q("     ",d);
   for(i=1;RaceList[i-1].what[0] != '\n'; i++) {
-    sprintf(buf,"%2d - %-15s ",i,RaceList[i-1].what);
+    SPRINTF(buf,"%2d - %-15s ",i,RaceList[i-1].what);
     if(!(i%3))
       strcat(buf,"\n\r     ");
     SEND_TO_Q(buf,d);

--- a/src/intrinsics.c
+++ b/src/intrinsics.c
@@ -49,7 +49,7 @@ void do_changeform(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   level = GET_LEVEL(ch, DRUID_LEVEL_IND) ;
 
   level = (level ? level : GetMaxLevel(ch)); /* for vampires */
-  sprintf(buf,"Level %d thing doing a changeform.",level);
+  SPRINTF(buf,"Level %d thing doing a changeform.",level);
   log_msg(buf);
 
   one_argument(argument,buf);
@@ -61,7 +61,7 @@ void do_changeform(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       send_to_char("     ", ch);
       for(mobn=1;  LAST_DRUID_MOB+1 >= mobn && level >= DruidList[mobn].level;
 	  mobn++) {
-	sprintf(buf,"%2d - %-15s ",DruidList[mobn].level,DruidList[mobn].name);
+	SPRINTF(buf,"%2d - %-15s ",DruidList[mobn].level,DruidList[mobn].name);
 	if(!(mobn%3))
 	  strcat(buf,"\n\r     ");
 	send_to_char(buf, ch);

--- a/src/limits.c
+++ b/src/limits.c
@@ -35,9 +35,9 @@ char *ClassTitles(struct char_data *ch)
       if (GET_LEVEL(ch, i)) {
 	count++;
 	if (count > 1) {
-	  sprintf(buf + strlen(buf), "/%s",GET_CLASS_TITLE(ch, i,GET_LEVEL(ch,i)));
+	  SAPPENDF(buf, "/%s",GET_CLASS_TITLE(ch, i,GET_LEVEL(ch,i)));
 	} else {
-	  sprintf(buf, "%s", GET_CLASS_TITLE(ch, i, GET_LEVEL(ch, i)));
+	  SPRINTF(buf, "%s", GET_CLASS_TITLE(ch, i, GET_LEVEL(ch, i)));
 	}
       }
     }
@@ -622,7 +622,7 @@ void set_title(struct char_data *ch)
   
   char buf[256];
   
-  sprintf(buf, 
+  SPRINTF(buf, 
      "the %s %s", RaceName[ch->race], ClassTitles(ch));
   
   if (GET_TITLE(ch)) {
@@ -647,7 +647,7 @@ void gain_exp(struct char_data *ch, int gain)
     if (ch->master->in_room == ch->in_room) {
       if (gain > 1) {
 	gain/=2;
-	sprintf(buf, "you gain $N's share of %d exp", gain);
+	SPRINTF(buf, "you gain $N's share of %d exp", gain);
 	act(buf, 0, ch->master, 0, ch, TO_CHAR);
 	gain_exp(ch->master, gain);
       }
@@ -683,7 +683,7 @@ void gain_exp(struct char_data *ch, int gain)
 	    } else if (GET_EXP(ch) >= titles[i][GET_LEVEL(ch,i)+1].exp) {
 	      /* do nothing..this is cool */
 	    } else if (GET_EXP(ch)+gain >= titles[i][GET_LEVEL(ch,i)+1].exp) {
-	      sprintf(buf, "You have gained enough to be a(n) %s\n\r", GET_CLASS_TITLE(ch, i, GET_LEVEL(ch, i)+1));
+	      SPRINTF(buf, "You have gained enough to be a(n) %s\n\r", GET_CLASS_TITLE(ch, i, GET_LEVEL(ch, i)+1));
 	      send_to_char(buf, ch);
 	      send_to_char("You must return to a guild to earn the level\n\r",ch);
 	      if (GET_EXP(ch)+gain >= titles[i][GET_LEVEL(ch,i)+2].exp) {

--- a/src/magic.c
+++ b/src/magic.c
@@ -1303,22 +1303,22 @@ void spell_locate_object(byte level, struct char_data *ch,
     if (isname(name, i->name)) {
       if(i->carried_by) {
 	if (strlen(PERS(i->carried_by, ch))>0) {
-          sprintf(buf2,"%s carried by %s.\n\r",
+          SPRINTF(buf2,"%s carried by %s.\n\r",
 		  i->short_description,PERS(i->carried_by,ch));
           strcat(buf, buf2);
 	}
       } else if(i->equipped_by) {
 	if (strlen(PERS(i->equipped_by, ch))>0) {
-          sprintf(buf2,"%s equipped by %s.\n\r",
+          SPRINTF(buf2,"%s equipped by %s.\n\r",
 		  i->short_description,PERS(i->equipped_by,ch));
           strcat(buf, buf2);
 	}
       } else if (i->in_obj) {
-	sprintf(buf2,"%s in %s.\n\r",i->short_description,
+	SPRINTF(buf2,"%s in %s.\n\r",i->short_description,
 		i->in_obj->short_description);
 	strcat(buf, buf2);
       } else {
-	sprintf(buf2,"%s in %s.\n\r",i->short_description,
+	SPRINTF(buf2,"%s in %s.\n\r",i->short_description,
 		(i->in_room == NOWHERE ? "use but uncertain." : real_roomp(i->in_room)->name));
 	strcat(buf, buf2);
 	j--;
@@ -1842,7 +1842,7 @@ void RawSummon( struct char_data *v, struct char_data *c)
   
   act("$n arrives suddenly.",TRUE,v,0,0,TO_ROOM);
   
-  sprintf(buf, "%s has summoned you!\n\r", (IS_NPC(c)?c->player.short_descr:GET_NAME(c)));
+  SPRINTF(buf, "%s has summoned you!\n\r", (IS_NPC(c)?c->player.short_descr:GET_NAME(c)));
   send_to_char(buf, v);
   do_look(v,"",15);
   
@@ -2105,12 +2105,12 @@ void spell_identify(byte level, struct char_data *ch,
   if (obj) {
     send_to_char("You feel informed:\n\r", ch);
     
-    sprintf(buf, "Object '%s', Item type: ", obj->name);
+    SPRINTF(buf, "Object '%s', Item type: ", obj->name);
     sprinttype(GET_ITEM_TYPE(obj),item_types,buf2);
     strcat(buf,buf2); strcat(buf,"\n\r");
     send_to_char(buf, ch);
     
-    sprintf(buf, "This item\'s ego is of %s proportions.\n\r",
+    SPRINTF(buf, "This item\'s ego is of %s proportions.\n\r",
 	    EgoDesc(GET_OBJ_EGO(obj)));
     send_to_char(buf, ch);
 
@@ -2126,7 +2126,7 @@ void spell_identify(byte level, struct char_data *ch,
     strcat(buf,"\n\r");
     send_to_char(buf,ch);
     
-    sprintf(buf,"Weight: %d\n\r",
+    SPRINTF(buf,"Weight: %d\n\r",
 	    obj->obj_flags.weight); 
     send_to_char(buf, ch);
 
@@ -2135,7 +2135,7 @@ void spell_identify(byte level, struct char_data *ch,
       
     case ITEM_SCROLL : 
     case ITEM_POTION :
-      sprintf(buf, "Level %d spells of:\n\r",	obj->obj_flags.value[0]);
+      SPRINTF(buf, "Level %d spells of:\n\r",	obj->obj_flags.value[0]);
       send_to_char(buf, ch);
       if (obj->obj_flags.value[1] >= 1) {
 	sprinttype(obj->obj_flags.value[1]-1,spells,buf);
@@ -2156,12 +2156,12 @@ void spell_identify(byte level, struct char_data *ch,
       
     case ITEM_WAND : 
     case ITEM_STAFF : 
-      sprintf(buf, "Has %d chages, with %d charges left.\n\r",
+      SPRINTF(buf, "Has %d chages, with %d charges left.\n\r",
 	      obj->obj_flags.value[1],
 	      obj->obj_flags.value[2]);
       send_to_char(buf, ch);
       
-      sprintf(buf, "Level %d spell of:\n\r",	obj->obj_flags.value[0]);
+      SPRINTF(buf, "Level %d spell of:\n\r",	obj->obj_flags.value[0]);
       send_to_char(buf, ch);
       
       if (obj->obj_flags.value[3] >= 1) {
@@ -2172,14 +2172,14 @@ void spell_identify(byte level, struct char_data *ch,
       break;
       
     case ITEM_WEAPON :
-      sprintf(buf, "Damage Dice is '%dD%d'\n\r",
+      SPRINTF(buf, "Damage Dice is '%dD%d'\n\r",
 	      obj->obj_flags.value[1],
 	      obj->obj_flags.value[2]);
       send_to_char(buf, ch);
       break;
       
     case ITEM_ARMOR :
-      sprintf(buf, "AC-apply is %d\n\r",
+      SPRINTF(buf, "AC-apply is %d\n\r",
 	      obj->obj_flags.value[0]);
       send_to_char(buf, ch);
       break;
@@ -2197,7 +2197,7 @@ void spell_identify(byte level, struct char_data *ch,
 	}
 	
 	sprinttype(obj->affected[i].location,apply_types,buf2);
-	sprintf(buf,"    Affects : %s By ", buf2);
+	SPRINTF(buf,"    Affects : %s By ", buf2);
 	send_to_char(buf,ch);
 	switch(obj->affected[i].location) {
 	case APPLY_M_IMMUNE:
@@ -2207,11 +2207,11 @@ void spell_identify(byte level, struct char_data *ch,
 	   strcat(buf2,"\n\r");
 	   break;
 	case APPLY_ATTACKS:
-	   sprintf(buf2,"%lu\n\r", obj->affected[i].modifier/10);
+	   SPRINTF(buf2,"%lu\n\r", obj->affected[i].modifier/10);
 	   break;
         case APPLY_WEAPON_SPELL:
 	case APPLY_EAT_SPELL:
-	   sprintf(buf2,"%s\n\r", spells[obj->affected[i].modifier-1]);
+	   SPRINTF(buf2,"%s\n\r", spells[obj->affected[i].modifier-1]);
 	   break;
 	case APPLY_SPELL:
 	   sprintbit(obj->affected[i].modifier,affected_bits, buf2);
@@ -2219,7 +2219,7 @@ void spell_identify(byte level, struct char_data *ch,
 	   break;
 
 	 default:
-	   sprintf(buf2,"%lu\n\r", obj->affected[i].modifier);
+	   SPRINTF(buf2,"%lu\n\r", obj->affected[i].modifier);
 	   break;
 	}
 	send_to_char(buf2,ch);
@@ -2233,21 +2233,21 @@ void spell_identify(byte level, struct char_data *ch,
       struct time_info_data ma;
 
       age2(victim, &ma);
-      sprintf(buf,"%d Years,  %d Months,  %d Days,  %d Hours old.\n\r",
+      SPRINTF(buf,"%d Years,  %d Months,  %d Days,  %d Hours old.\n\r",
 	      ma.year, ma.month,
 	      ma.day, ma.hours);
       send_to_char(buf,ch);
       
-      sprintf(buf,"Height %dcm  Weight %dpounds \n\r",
+      SPRINTF(buf,"Height %dcm  Weight %dpounds \n\r",
 	      GET_HEIGHT(victim), GET_WEIGHT(victim));
       send_to_char(buf,ch);
       
-      sprintf(buf,"Armor Class %d\n\r",victim->points.armor);
+      SPRINTF(buf,"Armor Class %d\n\r",victim->points.armor);
       send_to_char(buf,ch);
 
       if (level > 30) {
 
-	sprintf(buf,"Str %d/%d, Int %d, Wis %d, Dex %d, Con %d, Ch %d\n\r",
+	SPRINTF(buf,"Str %d/%d, Int %d, Wis %d, Dex %d, Con %d, Ch %d\n\r",
 	GET_STR(victim), GET_ADD(victim),
 	GET_INT(victim),
 	GET_WIS(victim),

--- a/src/magic2.c
+++ b/src/magic2.c
@@ -806,7 +806,7 @@ void spell_poly_self(byte UNUSED(level), struct char_data *ch,
 
   /* do some fiddling with the strings */
   buf = (char *)malloc(strlen(GET_NAME(mob)) + strlen(GET_NAME(ch)) + 2);
-  sprintf(buf, "%s %s", GET_NAME(ch), GET_NAME(mob));
+  SPRINTF(buf, "%s %s", GET_NAME(ch), GET_NAME(mob));
 
 #if TITAN
 #else
@@ -818,7 +818,7 @@ void spell_poly_self(byte UNUSED(level), struct char_data *ch,
   GET_NAME(mob) = buf;
   buf = (char *)malloc(strlen(mob->player.short_descr) 
 		       + strlen(GET_NAME(ch)) + 2);
-  sprintf(buf, "%s %s", GET_NAME(ch), mob->player.short_descr);
+  SPRINTF(buf, "%s %s", GET_NAME(ch), mob->player.short_descr);
 
 #if TITAN
   if (mob->player.short_descr)
@@ -827,7 +827,7 @@ void spell_poly_self(byte UNUSED(level), struct char_data *ch,
   mob->player.short_descr = buf;
 
   buf = (char *)malloc(strlen(mob->player.short_descr)+12);
-  sprintf(buf, "%s is here\n\r", mob->player.short_descr);
+  SPRINTF(buf, "%s is here\n\r", mob->player.short_descr);
 
 #if TITAN
 #else
@@ -1476,7 +1476,7 @@ void spell_animate_dead(byte level, struct char_data *ch,
   /*
     set up descriptions and such
     */ 
-  sprintf(buf,"%s is here, slowly animating\n\r",corpse->short_description);
+  SPRINTF(buf,"%s is here, slowly animating\n\r",corpse->short_description);
   mob->player.long_descr = strdup(buf);
   
   /*
@@ -1512,23 +1512,23 @@ void spell_know_alignment(byte UNUSED(level), struct char_data *ch,
    ap = GET_ALIGNMENT(victim);
    
    if (ap > 700) 
-      sprintf(buf,"%s has an aura as white as the driven snow.\n\r",name);
+      SPRINTF(buf,"%s has an aura as white as the driven snow.\n\r",name);
    else if (ap > 350)
-      sprintf(buf, "%s is of excellent moral character.\n\r",name);
+      SPRINTF(buf, "%s is of excellent moral character.\n\r",name);
    else if (ap > 100)
-      sprintf(buf, "%s is often kind and thoughtful.\n\r",name);
+      SPRINTF(buf, "%s is often kind and thoughtful.\n\r",name);
    else if (ap > 25)
-      sprintf(buf, "%s isn't a bad sort...\n\r",name);
+      SPRINTF(buf, "%s isn't a bad sort...\n\r",name);
    else if (ap > -25)
-      sprintf(buf, "%s doesn't seem to have a firm moral commitment\n\r",name);
+      SPRINTF(buf, "%s doesn't seem to have a firm moral commitment\n\r",name);
    else if (ap > -100)
-    sprintf(buf, "%s isn't the worst you've come across\n\r",name);
+    SPRINTF(buf, "%s isn't the worst you've come across\n\r",name);
    else if (ap > -350)
-    sprintf(buf, "%s could be a little nicer, but who couldn't?\n\r",name);
+    SPRINTF(buf, "%s could be a little nicer, but who couldn't?\n\r",name);
    else if (ap > -700)
-    sprintf(buf, "%s probably just had a bad childhood\n\r",name);
+    SPRINTF(buf, "%s probably just had a bad childhood\n\r",name);
    else 
-     sprintf(buf,"I'd rather just not say anything at all about %s\n\r",name);
+     SPRINTF(buf,"I'd rather just not say anything at all about %s\n\r",name);
 
    send_to_char(buf,ch);
    

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -103,7 +103,7 @@ void spell_speak_with_plants(byte UNUSED(level), struct char_data *ch,
     return;
   }
 
-  sprintf(buffer, "%s says 'Hi $n, how ya doin?'", 
+  SPRINTF(buffer, "%s says 'Hi $n, how ya doin?'", 
 	  fname(obj->name));
   act(buffer, FALSE, ch, obj, 0, TO_CHAR);
   act("$p rustles slightly.", FALSE, ch, obj, 0, TO_ROOM);
@@ -959,7 +959,7 @@ void spell_commune(byte UNUSED(level), struct char_data *ch,
 
     if (rp->zone == dp->zone) {
       if (!IS_SET(rp->room_flags, INDOORS)) {
-	sprintf(buf, "%s is in %s\n\r", (IS_NPC(c)?c->player.short_descr:GET_NAME(c)),rp->name);
+	SPRINTF(buf, "%s is in %s\n\r", (IS_NPC(c)?c->player.short_descr:GET_NAME(c)),rp->name);
 	if (strlen(buf)+strlen(buffer) > MAX_STRING_LENGTH-2)
 	  break;
 	strcat(buffer, buf);
@@ -2039,59 +2039,59 @@ void spell_know_monster(byte level, struct char_data *ch,
 */
 
   if (!IS_PC(victim)) {
-    sprintf(buf,"$N belongs to the %s race.", RaceName[GET_RACE(victim)]);
+    SPRINTF(buf,"$N belongs to the %s race.", RaceName[GET_RACE(victim)]);
     act(buf,FALSE, ch, 0, victim, TO_CHAR);
     if (level > 5) {
       exp = GetApprox(GET_EXP(victim), 40+level);
-      sprintf(buf, "$N is worth approximately %d experience", exp);
+      SPRINTF(buf, "$N is worth approximately %d experience", exp);
       act(buf,FALSE, ch, 0, victim, TO_CHAR);
     }
     if (level > 10) {
       lev = GetApprox(GetMaxLevel(victim), 40+level);
-      sprintf(buf, "$N fights like a %d level warrior, you think", lev);
+      SPRINTF(buf, "$N fights like a %d level warrior, you think", lev);
       act(buf,FALSE, ch, 0, victim, TO_CHAR);      
     }
     if (level > 15) {
       if (IS_SET(victim->hatefield, HATE_RACE)) {
-	sprintf(buf, "$n seems to hate the %s race", RaceName[victim->hates.race]);
+	SPRINTF(buf, "$n seems to hate the %s race", RaceName[victim->hates.race]);
 	act(buf,FALSE, ch, 0, victim, TO_CHAR);      
       }
       if (IS_SET(victim->hatefield, HATE_CLASS)) {
 	sprintbit((unsigned)victim->hates.class, pc_class_types, buf2);
-	sprintf(buf, "$n seems to hate the %s class(es)", buf2);
+	SPRINTF(buf, "$n seems to hate the %s class(es)", buf2);
 	act(buf,FALSE, ch, 0, victim, TO_CHAR);      
       }
     }
     if (level > 20) {
       hits = GetApprox(GET_MAX_HIT(victim), 40+level);
-      sprintf(buf,"$N probably has about %d hit points", hits);
+      SPRINTF(buf,"$N probably has about %d hit points", hits);
       act(buf,FALSE, ch, 0, victim, TO_CHAR);      
     }
     if (level > 25) {
       if (victim->susc) {
 	sprintbit(victim->susc, immunity_names, buf2);
-	sprintf(buf, "$N is susceptible to %s\n\r", buf2);
+	SPRINTF(buf, "$N is susceptible to %s\n\r", buf2);
 	act(buf,FALSE, ch, 0, victim, TO_CHAR);
       }
     }
     if (level > 30) {
       if (victim->immune) {
 	sprintbit(victim->immune, immunity_names, buf2);
-	sprintf(buf, "$N is resistant to %s\n\r", buf2);
+	SPRINTF(buf, "$N is resistant to %s\n\r", buf2);
 	act(buf,FALSE, ch, 0, victim, TO_CHAR);
       }
     }
     if (level > 35) {
       if (victim->M_immune) {
 	sprintbit(victim->M_immune, immunity_names, buf2);
-	sprintf(buf, "$N is immune to %s\n\r", buf2);
+	SPRINTF(buf, "$N is immune to %s\n\r", buf2);
 	act(buf,FALSE, ch, 0, victim, TO_CHAR);
       }
     }
     if (level > 40) {
       int att;
       att = GetApprox((int)victim->mult_att, 30+level);
-      sprintf(buf,"$N gets approx %d.0 attack(s) per round", att);
+      SPRINTF(buf,"$N gets approx %d.0 attack(s) per round", att);
       act(buf,FALSE, ch, 0, victim, TO_CHAR);
     }
     if (level > 45) {
@@ -2099,7 +2099,7 @@ void spell_know_monster(byte level, struct char_data *ch,
       no = GetApprox(victim->specials.damnodice, 30+level);
       s = GetApprox(victim->specials.damsizedice, 30+level);
 
-      sprintf(buf,"Each does about %dd%d points of damage", 
+      SPRINTF(buf,"Each does about %dd%d points of damage", 
 	      no, s);
       act(buf,FALSE, ch, 0, victim, TO_CHAR);
     }
@@ -2264,7 +2264,7 @@ void spell_portal(byte level, struct char_data *ch,
 
   if (!(nrp = real_roomp(tmp_ch->in_room))) {
     char str[180];
-    sprintf(str, "%s not in any room.", GET_NAME(tmp_ch));
+    SPRINTF(str, "%s not in any room.", GET_NAME(tmp_ch));
     log_msg(str);
     send_to_char("Your magic cannot locate the target.\n\r", ch);
     return;
@@ -2288,7 +2288,7 @@ void spell_portal(byte level, struct char_data *ch,
     return;
   }
 
-  sprintf(buf, "Through the mists of the portal, you can faintly see %s", nrp->name);
+  SPRINTF(buf, "Through the mists of the portal, you can faintly see %s", nrp->name);
 
   CREATE(ed , struct extra_descr_data, 1);
   ed->next = tmp_obj->ex_description;

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -103,7 +103,7 @@ void mobile_wander(struct char_data *ch)
 	go_direction(ch, door);
 	if (ch->in_room == 0) {
 	  if (or != 0) {
-	    sprintf(buf, "%s just entered void from %d", GET_NAME(ch), or);
+	    SPRINTF(buf, "%s just entered void from %d", GET_NAME(ch), or);
 	    log_sev(buf,5);
 	  }
 	}
@@ -182,7 +182,7 @@ void MobScavenge(struct char_data *ch)
 	cc++;
 	if (obj->contains) {
 	  if (IsHumanoid(ch) && !number(0,4)) {
-	    sprintf(buf, " all %d.corpse", cc);
+	    SPRINTF(buf, " all %d.corpse", cc);
 	    do_get(ch, buf, 0);
 	    return;
 	  }
@@ -222,7 +222,7 @@ void MobScavenge(struct char_data *ch)
 
   if (!number(0,3)) {
     if (IsHumanoid(ch) && ch->carrying) {
-      sprintf(buf, "all");
+      SPRINTF(buf, "all");
       do_wear(ch, buf, 0);
     }
   }
@@ -287,7 +287,7 @@ void mobile_activity(struct char_data *ch)
   if (((IS_SET(ch->specials.act, ACT_SPEC) || mob_index[ch->nr].func)) && !no_specials) {
     if (!mob_index[ch->nr].func) {
       char buf[180];
-      sprintf(buf, "Attempting to call a non-existing mob func on %s", GET_NAME(ch));
+      SPRINTF(buf, "Attempting to call a non-existing mob func on %s", GET_NAME(ch));
       log_msg(buf);
       REMOVE_BIT(ch->specials.act, ACT_SPEC);
     } else {
@@ -455,7 +455,7 @@ int AssistFriend( struct char_data *ch)
   assert(ch->in_room >= 0); 
 #else
   if (ch->in_room < 0) {
-    sprintf(buf, "Mob %s in negative room", ch->player.name);
+    SPRINTF(buf, "Mob %s in negative room", ch->player.name);
     log_msg(buf);
     ch->in_room = 0;
     extract_char(ch);
@@ -812,7 +812,7 @@ void sgoto(char *arg, struct char_data *ch)
        room = atoi(arg);
      }
    } else {
-     sprintf(buf, "Error in script %s, no destination for goto", 
+     SPRINTF(buf, "Error in script %s, no destination for goto", 
 	     script_data[ch->script].filename);
      log_msg(buf);
      ch->commandp++;
@@ -868,7 +868,7 @@ void do_jmp(char *arg, struct char_data *ch)
      }
   }
 
- sprintf(buf, "Label %s undefined in script assigned to %s.  Ignoring.", arg, GET_NAME(ch));
+ SPRINTF(buf, "Label %s undefined in script assigned to %s.  Ignoring.", arg, GET_NAME(ch));
  log_msg(buf);
 
  ch->commandp++;
@@ -891,7 +891,7 @@ void do_jsr(char *arg, struct char_data *ch)
      }
   }
 
- sprintf(buf, "Label %s undefined in script assigned to %s.  Ignoring.", arg, GET_NAME(ch));
+ SPRINTF(buf, "Label %s undefined in script assigned to %s.  Ignoring.", arg, GET_NAME(ch));
  log_msg(buf);
 
  ch->commandp++;

--- a/src/modify.c
+++ b/src/modify.c
@@ -1078,7 +1078,7 @@ void gr(int s)
   if (((ld = load()) >= 6) || (txt = nogames()) || slow_death)
     {
       if (ld >= 6)	{
-	  sprintf(buf, "The system load is greater than 6.0 (%d)\n\r", ld);
+	  SPRINTF(buf, "The system load is greater than 6.0 (%d)\n\r", ld);
 	  send_to_all(buf);
 	}
       else if (slow_death)

--- a/src/pcedit.c
+++ b/src/pcedit.c
@@ -390,7 +390,7 @@ void access_rent_files(int number, int ITEM, char buf[40]) {
     buf[j]='\0';
     if(buf[0]=='e')
     printf("\nAtteming to open %s's rent file.",buf);
-         if(strlen(buff) > sprintf) {
+         if(strlen(buff) > SPRINTF) {
       (,"~/lib/rent/%s",buff); 
       if((fl=fopen(buf,"r")) != NULL ) {
 	if(ReadObjs(fl,&muck)) {

--- a/src/reception.c
+++ b/src/reception.c
@@ -41,7 +41,7 @@ int add_obj_cost(struct char_data *ch, struct char_data *re,
       cost->total_cost += temp;
       if (re) {
 #if  0
-	sprintf(buf, "%30s : %d coins/day\n\r", obj->short_description, temp);
+	SPRINTF(buf, "%30s : %d coins/day\n\r", obj->short_description, temp);
 	send_to_char(buf, ch);
 #endif	
       }
@@ -110,7 +110,7 @@ bool recep_offer(struct char_data *ch,	struct char_data *receptionist,
   
   if (cost->no_carried > MAX_OBJ_SAVE) {
     if (receptionist) {
-      sprintf(buf,"$n tells you 'Sorry, but I can't store more than %d items.",
+      SPRINTF(buf,"$n tells you 'Sorry, but I can't store more than %d items.",
 	      MAX_OBJ_SAVE);
       act(buf,FALSE,receptionist,0,ch,TO_VICT);
     }
@@ -126,7 +126,7 @@ bool recep_offer(struct char_data *ch,	struct char_data *receptionist,
   
   if (receptionist) {
 
-    sprintf(buf, "$n tells you 'It will cost you %d coins per day'",
+    SPRINTF(buf, "$n tells you 'It will cost you %d coins per day'",
 	    cost->total_cost);
     act(buf,FALSE,receptionist,0,ch,TO_VICT);
   
@@ -163,7 +163,7 @@ void update_file(struct char_data *ch, struct obj_file_u *st)
 
     */
   write_char_extra(ch);
-  sprintf(buf, "rent/%s", lower(ch->player.name));
+  SPRINTF(buf, "rent/%s", lower(ch->player.name));
   ensure_rent_directory();
 #if 0
   for(p=buf;*p && *p != ' ';p++);
@@ -252,7 +252,7 @@ void load_char_objs(struct char_data *ch)
   load_char_extra(ch);
 
   
-  sprintf(buf, "rent/%s", lower(ch->player.name));
+  SPRINTF(buf, "rent/%s", lower(ch->player.name));
 
   
   /* r+b is for Binary Reading/Writing */
@@ -302,9 +302,9 @@ void load_char_objs(struct char_data *ch)
       timegold = (int) ((st.total_cost*((float)time(0) - st.last_update)) / 
 			(SECS_PER_REAL_DAY));
 #endif
-      sprintf(buf, "Char ran up charges of %g gold in rent", timegold);
+      SPRINTF(buf, "Char ran up charges of %g gold in rent", timegold);
       log_msg(buf);
-      sprintf(buf, "You ran up charges of %g gold in rent.\n\r", timegold);
+      SPRINTF(buf, "You ran up charges of %g gold in rent.\n\r", timegold);
       send_to_char(buf, ch);
       GET_GOLD(ch) -= timegold;
       found = TRUE;    
@@ -365,7 +365,7 @@ void put_obj_in_store(struct obj_data *obj, struct obj_file_u *st)
       if (obj->name)
          strcpy(oe->name, obj->name);
       else {
-	sprintf(buf, "object %d has no name!", obj_index[obj->item_number].virtual);
+	SPRINTF(buf, "object %d has no name!", obj_index[obj->item_number].virtual);
 	log_msg(buf);
 	
       }
@@ -410,7 +410,7 @@ void obj_to_store(struct obj_data *obj, struct obj_file_u *st,
   if ((obj->obj_flags.timer < 0) && (obj->obj_flags.timer != OBJ_NOTIMER)) {
 #if NODUPLICATES
 #else
-    sprintf(buf, "You're told: '%s is just old junk, I'll throw it away for you.'\n\r", obj->short_description);
+    SPRINTF(buf, "You're told: '%s is just old junk, I'll throw it away for you.'\n\r", obj->short_description);
     send_to_char(buf, ch);
 #endif
   } else if (obj->obj_flags.cost_per_day < 0) {
@@ -418,7 +418,7 @@ void obj_to_store(struct obj_data *obj, struct obj_file_u *st,
 #if NODUPLICATES
 #else
     if(ch != NULL) {
-      sprintf(buf, "You're told: '%s is just old junk, I'll throw it away for you.'\n\r", obj->short_description);
+      SPRINTF(buf, "You're told: '%s is just old junk, I'll throw it away for you.'\n\r", obj->short_description);
       send_to_char(buf, ch);
     }
 #endif
@@ -459,7 +459,7 @@ void save_obj(struct char_data *ch, struct obj_cost *cost, int delete)
   st.number = 0;
   st.gold_left = GET_GOLD(ch);
 
-  sprintf(buf, "saving %s:%d", fname(ch->player.name), GET_GOLD(ch));
+  SPRINTF(buf, "saving %s:%d", fname(ch->player.name), GET_GOLD(ch));
   slog(buf);
 
   st.total_cost = cost->total_cost;
@@ -506,17 +506,17 @@ void update_obj_file()
   }
   
   for (i=0; i<= top_of_p_table; i++) {
-    sprintf(buf, "rent/%s", lower(player_table[i].name));
+    SPRINTF(buf, "rent/%s", lower(player_table[i].name));
     /* r+b is for Binary Reading/Writing */
     if ((fl = fopen(buf, "r+b")) != NULL) {
 
       if (ReadObjs(fl, &st)) {
 	if (str_cmp(st.owner, player_table[i].name) != 0) {
-       sprintf(buf, "Ack!  Wrong person written into object file! (%s/%s)", st.owner, player_table[i].name);
+       SPRINTF(buf, "Ack!  Wrong person written into object file! (%s/%s)", st.owner, player_table[i].name);
 	  log_msg(buf);
 	  abort();
 	} else {
-	  sprintf(buf, "   Processing %s[%ld].", st.owner, i);
+	  SPRINTF(buf, "   Processing %s[%ld].", st.owner, i);
 	  log_msg(buf);
 	  days_passed = ((time(0) - st.last_update) / SECS_PER_REAL_DAY);
 	  secs_lost = ((time(0) - st.last_update) % SECS_PER_REAL_DAY);
@@ -529,7 +529,7 @@ void update_obj_file()
 	    ch_st.load_room = NOWHERE;
 	    st.last_update = time(0)+3600;  /* one hour grace period */
 
-	    sprintf(buf, "   Deautorenting %s", st.owner);
+	    SPRINTF(buf, "   Deautorenting %s", st.owner);
 	    log_msg(buf);
 
 #if LIMITED_ITEMS
@@ -551,7 +551,7 @@ void update_obj_file()
 	      
 	      if ((st.total_cost*days_passed) > st.gold_left) {
 		
-		sprintf(buf, "   Dumping %s from object file.", ch_st.name);
+		SPRINTF(buf, "   Dumping %s from object file.", ch_st.name);
 		log_msg(buf);
 		
 		ch_st.points.gold = 0;
@@ -565,7 +565,7 @@ void update_obj_file()
 		
 	      } else {
 		
-		sprintf(buf, "   Updating %s", st.owner);
+		SPRINTF(buf, "   Updating %s", st.owner);
 		log_msg(buf);
 		st.gold_left  -= (st.total_cost*days_passed);
 		st.last_update = time(0)-secs_lost;
@@ -584,7 +584,7 @@ void update_obj_file()
 #if LIMITED_ITEMS
 	      CountLimitedItems(&st);
 #endif
-	      sprintf(buf, "  same day update on %s", st.owner);
+	      SPRINTF(buf, "  same day update on %s", st.owner);
 	      log_msg(buf);
 #if 0
 	      rewind(fl);
@@ -644,7 +644,7 @@ void PrintLimitedItems() {
   char buf[200];
   for (i=0;i<=top_of_objt;i++) {
     if (obj_index[i].number > 0) {
-      sprintf(buf, "item> %d [%d]", obj_index[i].virtual, obj_index[i].number);
+      SPRINTF(buf, "item> %d [%d]", obj_index[i].virtual, obj_index[i].number);
       log_msg(buf);
     }
   }
@@ -822,7 +822,7 @@ void ZeroRent( char *n)
 
   ensure_rent_directory();
 
-  sprintf(buf, "rent/%s", lower(n));
+  SPRINTF(buf, "rent/%s", lower(n));
 
   if (!(fl = fopen(buf, "w"))) {
     perror("saving PC's objects");
@@ -905,7 +905,7 @@ void load_char_extra(struct char_data *ch)
   char *p, *s, *chk;
   int n;
 
-  sprintf(buf, "rent/%s.aux", GET_NAME(ch));
+  SPRINTF(buf, "rent/%s.aux", GET_NAME(ch));
 
   /*
     open the file.. read in the lines, use them as the aliases and
@@ -949,7 +949,7 @@ void load_char_extra(struct char_data *ch)
 	    s[strlen(s)]= '\0';
 	    n = atoi(p);
 	    if (n >=0 && n <= 9) {  /* set up alias */
-	      sprintf(tmp, "%d %s", n, s+1);
+	      SPRINTF(tmp, "%d %s", n, s+1);
 	      do_alias(ch, tmp, 260);
 	    }
 	  }
@@ -968,7 +968,7 @@ void write_char_extra( struct char_data *ch)
   char buf[80];
   int i;
 
-  sprintf(buf, "rent/%s.aux", GET_NAME(ch));
+  SPRINTF(buf, "rent/%s.aux", GET_NAME(ch));
 
   /*
     open the file.. read in the lines, use them as the aliases and
@@ -1065,7 +1065,7 @@ void load_room_objs(int room)
   struct obj_file_u st;
   char buf[200];
   
-  sprintf(buf, "world/%d", room);
+  SPRINTF(buf, "world/%d", room);
 
   
   /* r+b is for Binary Reading/Writing */
@@ -1100,7 +1100,7 @@ void save_room(int room)
  rm = real_roomp(room);
 
  obj = rm->contents;
- sprintf(buf, "world/%d", room);
+ SPRINTF(buf, "world/%d", room);
  st.number = 0;
 
  if(obj) {
@@ -1114,7 +1114,7 @@ void save_room(int room)
 
    rewind(f1);
    obj_to_store(obj, &st, NULL, 0);
-   sprintf(buf, "Room %d", room);
+   SPRINTF(buf, "Room %d", room);
    strcpy(st.owner, buf);
    st.gold_left = 0;
    st.total_cost = 0;

--- a/src/rentedit.c
+++ b/src/rentedit.c
@@ -99,7 +99,7 @@ void main (int argc,char *argv[])
       for(i=0;grunt.name[i] != '\0' && i < 25;i++)
 	grunt.name[i] = tolower(grunt.name[i]);
       
-      sprintf(RentFileName,"%s%s",RENTDIR,grunt.name);
+      SPRINTF(RentFileName,"%s%s",RENTDIR,grunt.name);
       /*       printf("%s",RentFileName); */
 
       if((rf=fopen(RentFileName,"r"))==NULL)

--- a/src/security.c
+++ b/src/security.c
@@ -4,6 +4,7 @@
   See license.doc for distribution terms.   SillyMUD is based on DIKUMUD
 */
 #include "config.h"
+#include "utils.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -15,10 +16,10 @@ int SecCheck(char *arg, char *site)
  char buf[255], buf2[255];
  FILE *f1;
 
- sprintf(buf, "security/%s", arg);
+ SPRINTF(buf, "security/%s", arg);
 
  if(!(f1 = fopen(buf, "rt"))) {
-    sprintf(buf, "Unable to open security file for %s.", arg);
+    SPRINTF(buf, "Unable to open security file for %s.", arg);
     log_msg(buf);
     return(-1);
   }
@@ -27,7 +28,7 @@ int SecCheck(char *arg, char *site)
  fclose(f1);
 
  if(!*buf2) {
-    sprintf(buf, "Security file for %s empty.", arg);
+    SPRINTF(buf, "Security file for %s empty.", arg);
     log_msg(buf);
     return(-1);
   }
@@ -38,7 +39,7 @@ int SecCheck(char *arg, char *site)
  if(!(strncmp(site, buf2, strlen(buf2)))) {
     return(1);
   }
-    sprintf(buf, "Site %s and %s don't match for %s. Booting.", site, buf2, arg);
+    SPRINTF(buf, "Site %s and %s don't match for %s. Booting.", site, buf2, arg);
      log_msg(buf);
 
  return(0);

--- a/src/shop.c
+++ b/src/shop.c
@@ -144,7 +144,7 @@ void shopping_buy( char *arg, struct char_data *ch,
   
   only_argument(arg, argm);
   if(!(*argm))   {
-    sprintf(buf, "%s what do you want to buy??", GET_NAME(ch));
+    SPRINTF(buf, "%s what do you want to buy??", GET_NAME(ch));
     do_tell(keeper,buf,19);
     return;
   }
@@ -156,7 +156,7 @@ void shopping_buy( char *arg, struct char_data *ch,
   
   if(!( temp1 = 
        get_obj_in_list_vis(ch,argm,keeper->carrying)))    {
-    sprintf(buf,
+    SPRINTF(buf,
 	    shop_index[shop_nr].no_such_item1
 	    ,GET_NAME(ch));
     do_tell(keeper,buf,19);
@@ -164,7 +164,7 @@ void shopping_buy( char *arg, struct char_data *ch,
   }
   
   if(temp1->obj_flags.cost <= 0)    {
-    sprintf(buf,
+    SPRINTF(buf,
 	    shop_index[shop_nr].no_such_item1
 	    ,GET_NAME(ch));
     do_tell(keeper,buf,19);
@@ -195,7 +195,7 @@ void shopping_buy( char *arg, struct char_data *ch,
 #endif 
  
   if (GET_GOLD(ch) < (int) (num* cost)) {
-  sprintf(buf,
+  SPRINTF(buf,
 	  shop_index[shop_nr].missing_cash2,
 	  GET_NAME(ch));
   do_tell(keeper,buf,19);
@@ -214,7 +214,7 @@ void shopping_buy( char *arg, struct char_data *ch,
   
   if ((IS_CARRYING_N(ch) + num) > (CAN_CARRY_N(ch)))
     {
-      sprintf(buf,"%s : You can't carry that many items.\n\r", 
+      SPRINTF(buf,"%s : You can't carry that many items.\n\r", 
 	      fname(temp1->name));
       send_to_char(buf, ch);
       return;
@@ -222,7 +222,7 @@ void shopping_buy( char *arg, struct char_data *ch,
   
   if ((IS_CARRYING_W(ch) + (num * temp1->obj_flags.weight)) > CAN_CARRY_W(ch))
     {
-      sprintf(buf,"%s : You can't carry that much weight.\n\r", 
+      SPRINTF(buf,"%s : You can't carry that much weight.\n\r", 
 	      fname(temp1->name));
       send_to_char(buf, ch);
       return;
@@ -230,12 +230,12 @@ void shopping_buy( char *arg, struct char_data *ch,
   
   act("$n buys $p.", FALSE, ch, temp1, 0, TO_ROOM);
   
-  sprintf(buf, shop_index[shop_nr].message_buy,
+  SPRINTF(buf, shop_index[shop_nr].message_buy,
 	  GET_NAME(ch), (int) (num*cost));
   
   do_tell(keeper,buf,19);
   
-  sprintf(buf,"You now have %s (*%d).\n\r",
+  SPRINTF(buf,"You now have %s (*%d).\n\r",
 	  temp1->short_description,num);
   
   send_to_char(buf,ch);
@@ -296,14 +296,14 @@ void shopping_sell( char *arg, struct char_data *ch,
   only_argument(arg, argm);
   
   if(!(*argm))	{
-    sprintf(buf, "%s What do you want to sell??"
+    SPRINTF(buf, "%s What do you want to sell??"
 	    ,GET_NAME(ch));
     do_tell(keeper,buf,19);
     return;
   }
   
   if (!( temp1 = get_obj_in_list_vis(ch,argm,ch->carrying))) {
-    sprintf(buf, shop_index[shop_nr].no_such_item2,GET_NAME(ch));
+    SPRINTF(buf, shop_index[shop_nr].no_such_item2,GET_NAME(ch));
     do_tell(keeper,buf,19);
     return;
   }
@@ -315,7 +315,7 @@ void shopping_sell( char *arg, struct char_data *ch,
   }
 
   if (!(trade_with(temp1,shop_nr))||(temp1->obj_flags.cost<1)) {
-    sprintf(buf,shop_index[shop_nr].do_not_buy,
+    SPRINTF(buf,shop_index[shop_nr].do_not_buy,
 	    GET_NAME(ch));
     do_tell(keeper,buf,19);
     return;
@@ -333,7 +333,7 @@ void shopping_sell( char *arg, struct char_data *ch,
     cost = 1;
   
   if (GET_GOLD(keeper)<(int) cost) {
-    sprintf(buf,shop_index[shop_nr].missing_cash1,GET_NAME(ch));
+    SPRINTF(buf,shop_index[shop_nr].missing_cash1,GET_NAME(ch));
     do_tell(keeper,buf,19);
     return;
   }
@@ -359,7 +359,7 @@ void shopping_sell( char *arg, struct char_data *ch,
   temp_cost = (int) cost;
   if(temp_cost < 0) temp_cost=1;
 
-  sprintf(buf,shop_index[shop_nr].message_sell,GET_NAME(ch),temp_cost);
+  SPRINTF(buf,shop_index[shop_nr].message_sell,GET_NAME(ch),temp_cost);
 
 /* (int) (temp1->obj_flags.cost*	
 		shop_index[shop_nr].profit_sell +
@@ -368,7 +368,7 @@ void shopping_sell( char *arg, struct char_data *ch,
   
   do_tell(keeper,buf,19);
   
-  sprintf(buf,"The shopkeeper now has %s.\n\r",
+  SPRINTF(buf,"The shopkeeper now has %s.\n\r",
 	  temp1->short_description);
   send_to_char(buf,ch);
   
@@ -377,7 +377,7 @@ void shopping_sell( char *arg, struct char_data *ch,
 	      shop_index[shop_nr].profit_sell +
  	      ((chr_apply[GET_CHR(ch)].reaction*temp1->obj_flags.cost)/100))) {
  */
-    sprintf(buf,shop_index[shop_nr].missing_cash1 ,GET_NAME(ch));
+    SPRINTF(buf,shop_index[shop_nr].missing_cash1 ,GET_NAME(ch));
     do_tell(keeper,buf,19);
     return;
   }
@@ -434,21 +434,21 @@ void shopping_value( char *arg, struct char_data *ch,
   only_argument(arg, argm);
   
   if(!(*argm))    {
-      sprintf(buf,"%s What do you want me to evaluate??",
+      SPRINTF(buf,"%s What do you want me to evaluate??",
 	      GET_NAME(ch));
       do_tell(keeper,buf,19);
       return;
     }
   
   if(!( temp1 = get_obj_in_list_vis(ch,argm,ch->carrying)))    {
-      sprintf(buf,shop_index[shop_nr].no_such_item2,
+      SPRINTF(buf,shop_index[shop_nr].no_such_item2,
 	      GET_NAME(ch));
       do_tell(keeper,buf,19);
       return;
     }
   
   if(!(trade_with(temp1,shop_nr)))    {
-      sprintf(buf,
+      SPRINTF(buf,
 	      shop_index[shop_nr].do_not_buy,
 	      GET_NAME(ch));
       do_tell(keeper,buf,19);
@@ -464,7 +464,7 @@ void shopping_value( char *arg, struct char_data *ch,
   if(DoIHateYou(ch))
     cost /= 2;
 
-  sprintf(buf,"%s I'll give you %d gold coins for that!",
+  SPRINTF(buf,"%s I'll give you %d gold coins for that!",
 	  GET_NAME(ch),(int)cost);
 
   do_tell(keeper,buf,19);
@@ -528,16 +528,16 @@ void shopping_list(char * UNUSED(arg), struct char_data *ch,
 
 	if(temp1->obj_flags.type_flag != ITEM_DRINKCON) {
 	  
-	  sprintf(buf2,"%s for %d gold coins.\n\r" ,
+	  SPRINTF(buf2,"%s for %d gold coins.\n\r" ,
 		  (temp1->short_description),
 		  cost);
 	  } else {
 	    if (temp1->obj_flags.value[1])
-	      sprintf(buf3,"%s of %s",(temp1->short_description)
+	      SPRINTF(buf3,"%s of %s",(temp1->short_description)
 		      ,drinks[temp1->obj_flags.value[2]]);
 	    else
-	      sprintf(buf3,"%s",(temp1->short_description));
-	    sprintf(buf2,"%s for %d gold coins.\n\r",buf3,cost);
+	      SPRINTF(buf3,"%s",(temp1->short_description));
+	    SPRINTF(buf2,"%s for %d gold coins.\n\r",buf3,cost);
 	  }
 	  strcat(buf,CAP(buf2));
 	};
@@ -555,13 +555,13 @@ void shopping_kill(char * UNUSED(arg), struct char_data *ch,
   
   switch(shop_index[shop_nr].temper2){
   case 0:
-    sprintf(buf,"%s Don't ever try that again!",
+    SPRINTF(buf,"%s Don't ever try that again!",
 	    GET_NAME(ch));
     do_tell(keeper,buf,19);
     return;
     
   case 1:
-    sprintf(buf,"%s Scram - midget!",
+    SPRINTF(buf,"%s Scram - midget!",
 	    GET_NAME(ch));
     do_tell(keeper,buf,19);
     return;
@@ -738,7 +738,7 @@ void boot_the_shops()
 	char *fmt = "***WARNING***: Shop %d has invalid keeper mobile %d";
 	char *buf;
 	buf = (char *)malloc(strlen(fmt) + 40);
-	sprintf(buf, fmt, number_of_shops, keeper);
+	SPRINTF(buf, fmt, number_of_shops, keeper);
 	log_msg(buf);
 	free(buf);
       }

--- a/src/skills.c
+++ b/src/skills.c
@@ -159,9 +159,9 @@ void do_inset(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 
   /* add an extra description for the stone to the object*/
   CREATE(new_descr, struct extra_descr_data, 1);
-  sprintf(buf, "%s hilt",sword->name);
+  SPRINTF(buf, "%s hilt",sword->name);
   new_descr->keyword = strdup(buf);
-  sprintf(buf, "It is inset with %s", gem->short_description);
+  SPRINTF(buf, "It is inset with %s", gem->short_description);
   new_descr->description = strdup(buf);
   new_descr->next = sword->ex_description;
   sword->ex_description = new_descr;
@@ -442,7 +442,7 @@ void do_track(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   } else {
     if (IS_LIGHT(ch->in_room) || IS_AFFECTED(ch, AFF_TRUE_SIGHT) ) {
       SET_BIT(ch->specials.act, PLR_HUNTING);
-      sprintf(buf, "You see traces of your quarry to the %s.\n\r", dirs[code]);
+      SPRINTF(buf, "You see traces of your quarry to the %s.\n\r", dirs[code]);
       send_to_char(buf,ch);
     } else {
       ch->specials.hunting = 0;
@@ -480,7 +480,7 @@ int track( struct char_data *ch, struct char_data *vict)
     send_to_char("##You have lost the trail.\n\r",ch);
     return(FALSE);
   } else {
-    sprintf(buf, "##You see a faint trail to the %s.\n\r", dirs[code]);
+    SPRINTF(buf, "##You see a faint trail to the %s.\n\r", dirs[code]);
     send_to_char(buf, ch);
     return(TRUE);
   }
@@ -516,7 +516,7 @@ int dir_track( struct char_data *ch, struct char_data *vict)
     }
     return(-1);  /* false to continue the hunt */
   } else {
-    sprintf(buf, "##You see a faint trail to the %s.\n\r", dirs[code]);
+    SPRINTF(buf, "##You see a faint trail to the %s.\n\r", dirs[code]);
     send_to_char(buf, ch);
     return(code);
   }
@@ -703,10 +703,10 @@ void slam_into_wall( struct char_data *ch, struct room_direction_data *exitp)
   } else {
     strcpy(doorname, "barrier");
   }
-  sprintf(buf, "You slam against the %s with no effect.\n\r", doorname);
+  SPRINTF(buf, "You slam against the %s with no effect.\n\r", doorname);
   send_to_char(buf, ch);
   send_to_char("OUCH!  That REALLY Hurt!\n\r", ch);
-  sprintf(buf, "$n crashes against the %s with no effect.\n\r", doorname);
+  SPRINTF(buf, "$n crashes against the %s with no effect.\n\r", doorname);
   act(buf, FALSE, ch, 0, 0, TO_ROOM);
   GET_HIT(ch) -= number(1, 10)*2;
   if (GET_HIT(ch) < 0)
@@ -772,9 +772,9 @@ void do_doorbash( struct char_data *ch, char *arg, int UNUSED(cmd)) {
     }
   }
   
-  sprintf(buf, "$n charges %swards", dirs[dir]);
+  SPRINTF(buf, "$n charges %swards", dirs[dir]);
   act(buf, FALSE, ch, 0, 0, TO_ROOM);
-  sprintf(buf, "You charge %swards\n\r", dirs[dir]);
+  SPRINTF(buf, "You charge %swards\n\r", dirs[dir]);
   send_to_char(buf, ch);
 
   if (!IS_SET(exitp->exit_info, EX_CLOSED)) {
@@ -822,10 +822,10 @@ void do_doorbash( struct char_data *ch, char *arg, int UNUSED(cmd)) {
 	/*
 	  unlock and open the door
 	  */
-	sprintf(buf, "$n slams into the %s, and it bursts open!", 
+	SPRINTF(buf, "$n slams into the %s, and it bursts open!", 
 		fname(exitp->keyword));
 	act(buf, FALSE, ch, 0, 0, TO_ROOM);
-	sprintf(buf, "You slam into the %s, and it bursts open!\n\r", 
+	SPRINTF(buf, "You slam into the %s, and it bursts open!\n\r", 
 		fname(exitp->keyword));
 	send_to_char(buf, ch);
 	raw_unlock_door(ch, exitp, dir);
@@ -1179,9 +1179,9 @@ void do_climb( struct char_data *ch, char *arg, int UNUSED(cmd)) {
     return;
   }
 
-  sprintf(buf, "$n attempts to climb %swards", dirs[dir]);
+  SPRINTF(buf, "$n attempts to climb %swards", dirs[dir]);
   act(buf, FALSE, ch, 0, 0, TO_ROOM);
-  sprintf(buf, "You attempt to climb %swards\n\r", dirs[dir]);
+  SPRINTF(buf, "You attempt to climb %swards\n\r", dirs[dir]);
   send_to_char(buf, ch);
 
   GET_MOVE(ch) -= 10;
@@ -1304,7 +1304,7 @@ void do_palm( struct char_data *ch, char *arg, int cmd)
 	      if (obj_object->obj_flags.value[0]<1)
 		obj_object->obj_flags.value[0] = 1;
 	      obj_from_char(obj_object);
-	      sprintf(buffer,"There %s %d coins.\n\r",
+	      SPRINTF(buffer,"There %s %d coins.\n\r",
 		      obj_object->obj_flags.value[0] > 1 ? "were" : "was",
 		      obj_object->obj_flags.value[0]);
 	      send_to_char(buffer,ch);
@@ -1312,7 +1312,7 @@ void do_palm( struct char_data *ch, char *arg, int cmd)
 	      if (GET_GOLD(ch) > 100000 && 
 		  obj_object->obj_flags.value[0] > 10000) {
 		char buf[MAX_INPUT_LENGTH];
-		sprintf(buf,"%s just got %d coins!",
+		SPRINTF(buf,"%s just got %d coins!",
 			GET_NAME(ch),obj_object->obj_flags.value[0]);
 		log_msg(buf);
 	      }
@@ -1323,19 +1323,19 @@ void do_palm( struct char_data *ch, char *arg, int cmd)
 	    return;
 	  }
 	} else {
-	  sprintf(buffer,"%s : You can't carry that much weight.\n\r",
+	  SPRINTF(buffer,"%s : You can't carry that much weight.\n\r",
 		  obj_object->short_description);
 	  send_to_char(buffer, ch);
 	  return;
 	}
       } else {
-	sprintf(buffer,"%s : You can't carry that many items.\n\r",
+	SPRINTF(buffer,"%s : You can't carry that many items.\n\r",
 		obj_object->short_description);
 	send_to_char(buffer, ch);
 	return;
       }
     } else {
-      sprintf(buffer,"You do not see a %s here.\n\r", arg1);
+      SPRINTF(buffer,"You do not see a %s here.\n\r", arg1);
       send_to_char(buffer, ch);
       return;
     }
@@ -1365,7 +1365,7 @@ void do_palm( struct char_data *ch, char *arg, int cmd)
 		    if (obj_object->obj_flags.value[0]<1)
 		      obj_object->obj_flags.value[0] = 1;
 		    obj_from_char(obj_object);
-		    sprintf(buffer,"There %s %d coins.\n\r",
+		    SPRINTF(buffer,"There %s %d coins.\n\r",
 			   obj_object->obj_flags.value[0] > 1 ? "were" : "was",
 			    obj_object->obj_flags.value[0]);
 		    send_to_char(buffer,ch);
@@ -1373,7 +1373,7 @@ void do_palm( struct char_data *ch, char *arg, int cmd)
 		    if (GET_GOLD(ch) > 100000 &&
 			obj_object->obj_flags.value[0] > 10000) {
 		      char buf[MAX_INPUT_LENGTH];
-		      sprintf(buf,"%s just got %d coins!",
+		      SPRINTF(buf,"%s just got %d coins!",
 			      GET_NAME(ch),obj_object->obj_flags.value[0]);
 		      log_msg(buf);
 		    }
@@ -1386,26 +1386,26 @@ void do_palm( struct char_data *ch, char *arg, int cmd)
 		send_to_char("You can't take that.\n\r", ch);
 	      }
 	    } else {
-	      sprintf(buffer,"%s : You can't carry that much weight.\n\r",
+	      SPRINTF(buffer,"%s : You can't carry that much weight.\n\r",
 		      obj_object->short_description);
 	      send_to_char(buffer, ch);
 	    }
 	  } else {
-	    sprintf(buffer,"%s : You can't carry that many items.\n\r",
+	    SPRINTF(buffer,"%s : You can't carry that many items.\n\r",
 		    obj_object->short_description);
 	    send_to_char(buffer, ch);
 	  }
 	} else {
-	  sprintf(buffer,"%s does not contain the %s.\n\r",
+	  SPRINTF(buffer,"%s does not contain the %s.\n\r",
 		  sub_object->short_description, arg1);
 	  send_to_char(buffer, ch);
 	}
       } else {
-	sprintf(buffer,"%s is not a container.\n\r", 
+	SPRINTF(buffer,"%s is not a container.\n\r", 
 		sub_object->short_description);
       }
     } else {
-      sprintf(buffer,"You do not see or have the %s.\n\r", arg2);
+      SPRINTF(buffer,"You do not see or have the %s.\n\r", arg2);
       send_to_char(buffer, ch);
     }
   }
@@ -1595,7 +1595,7 @@ void do_makepotion(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 
   {
     char buf[80];
-    sprintf(buf,"Min brew level is: %d", max);
+    SPRINTF(buf,"Min brew level is: %d", max);
     log_msg(buf);
   }
 

--- a/src/spec_assign.c
+++ b/src/spec_assign.c
@@ -1081,7 +1081,7 @@ void assign_mobiles()
   for (i=0; specials[i].vnum>=0; i++) {
     rnum = real_mobile(specials[i].vnum);
     if (rnum<0) {
-      sprintf(buf, "mobile_assign: Mobile %d not found in database.",
+      SPRINTF(buf, "mobile_assign: Mobile %d not found in database.",
 	      specials[i].vnum);
       log_msg(buf);
     } else {
@@ -1131,7 +1131,7 @@ void assign_objects() {
       const char *fmt = "***WARNING***: assigning special proc to non-existent object %d";
       char *buf;
       buf = (char *)malloc(strlen(fmt) + 20);
-      sprintf(buf, fmt, obj_procs[i].virtual_obj_num);
+      SPRINTF(buf, fmt, obj_procs[i].virtual_obj_num);
       log_msg(buf);
       free(buf);
     }
@@ -1182,7 +1182,7 @@ void assign_rooms()
   for (i=0; specials[i].vnum>=0; i++) {
     rp = real_roomp(specials[i].vnum);
     if (rp==NULL) {
-      sprintf(buf,"assign_rooms: room %d unknown",specials[i].vnum);
+      SPRINTF(buf,"assign_rooms: room %d unknown",specials[i].vnum);
       log_msg(buf);
     } else
       rp->funct = specials[i].proc;

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -276,7 +276,7 @@ int Guildmaster(struct char_data *ch, int cmd, char *arg,
         }
         return(TRUE);
       default:
-        sprintf(buf, "Strangeness in guildmaster, class %d passed in by %s.",
+        SPRINTF(buf, "Strangeness in guildmaster, class %d passed in by %s.",
 		class, GET_NAME(ch));
         log_msg(buf);
         send_to_char(" 'Ack! I feel faint!'\n\r", ch);
@@ -284,7 +284,7 @@ int Guildmaster(struct char_data *ch, int cmd, char *arg,
       }
     }
     if (!*arg) {
-      sprintf(buf,"You have got %d practice sessions left.\n\r",
+      SPRINTF(buf,"You have got %d practice sessions left.\n\r",
               ch->specials.spells_to_learn);
       send_to_char(buf, ch);
       switch(class) {
@@ -299,7 +299,7 @@ int Guildmaster(struct char_data *ch, int cmd, char *arg,
               (skill_info[i+1].min_level[level_num] <=
                GetMaxLevel(guildmaster)-10)) {
 
-            sprintf(buf,"[%-2d] %-30s %s \n\r",
+            SPRINTF(buf,"[%-2d] %-30s %s \n\r",
                     skill_info[i+1].min_level[level_num],
                     spells[i],how_good(ch->skills[i+1].learned));
             send_to_char(buf, ch);
@@ -313,14 +313,14 @@ int Guildmaster(struct char_data *ch, int cmd, char *arg,
         send_to_char("You can practice any of the following skills:\n\r", ch);
         for(i=0; *spells[i] != '\n'; i++) {
           if (skill_info[i+1].taught_by & teacher) {
-            sprintf(buf, "%-30s %s\n\r", spells[i],
+            SPRINTF(buf, "%-30s %s\n\r", spells[i],
                     how_good(ch->skills[i+1].learned));
             send_to_char(buf, ch);
           }
         }
         return(TRUE);
       default:
-        sprintf(buf, "Strangeness in guildmaster for class %d.\n\r",class);
+        SPRINTF(buf, "Strangeness in guildmaster for class %d.\n\r",class);
         log_msg(buf);
         send_to_char("Ack, I feel faint!\n\r", ch);
       } /* switch */
@@ -400,7 +400,7 @@ int dump(struct char_data *ch, int cmd, char *arg,
   char *fname(char *namelist);
   
   for(k = real_roomp(ch->in_room)->contents; k ; k = real_roomp(ch->in_room)->contents)    {
-      sprintf(buf, "The %s vanish in a puff of smoke.\n\r" ,fname(k->name));
+      SPRINTF(buf, "The %s vanish in a puff of smoke.\n\r" ,fname(k->name));
       for(tmp_char = real_roomp(ch->in_room)->people; tmp_char;
 	  tmp_char = tmp_char->next_in_room)
 	if (CAN_SEE_OBJ(tmp_char, k))
@@ -416,7 +416,7 @@ int dump(struct char_data *ch, int cmd, char *arg,
   
   for(k = real_roomp(ch->in_room)->contents; k ; 
       k = real_roomp(ch->in_room)->contents)    {
-      sprintf(buf, "The %s vanishes in a puff of smoke.\n\r",fname(k->name));
+      SPRINTF(buf, "The %s vanishes in a puff of smoke.\n\r",fname(k->name));
       for(tmp_char = real_roomp(ch->in_room)->people; tmp_char;
 	  tmp_char = tmp_char->next_in_room)
 	if (CAN_SEE_OBJ(tmp_char, k))
@@ -776,7 +776,7 @@ int andy_wilcox(struct char_data *ch, int cmd, char *arg,
       cost *= 9;
       cost /=10;
       cost++;
-      sprintf(buf,"%s for %d gold coins.\n\r", temp1->short_description, cost);
+      SPRINTF(buf,"%s for %d gold coins.\n\r", temp1->short_description, cost);
       send_to_char(buf, ch);
       extract_obj(temp1);
       if (temp2)
@@ -1067,7 +1067,7 @@ int eric_johnson(struct char_data *ch, int cmd, char * UNUSED(arg),
 					    eric->carrying)) {
 	      char	*s;
 	      s = (scan[0][1] == '.') ? scan[0]+2 : scan[0];
-	      sprintf(buf, "buy %s", s);
+	      SPRINTF(buf, "buy %s", s);
 	      command_interpreter(eric, buf);
 	      if (NULL == get_obj_in_list_vis(eric, *scan,
 					      eric->carrying)) {
@@ -1882,7 +1882,7 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
   switch (number(0, 250))
     {
     case 0:
-      sprintf(buf,"Pass the bong, dude\n");
+      SPRINTF(buf,"Pass the bong, dude\n");
       do_say(ch, buf, 0);
       return(1);
     case 1:
@@ -1925,10 +1925,10 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
 	      } else if (!strcmp(GET_NAME(i), "God")) {
 		do_shout(ch, "God!  Theres only room for one smartass robot on this mud!",0);
 	      } else if (GET_SEX(i)==SEX_MALE) {
-		sprintf(buf,"Hey, %s, how about some MUDSex?",GET_NAME(i));
+		SPRINTF(buf,"Hey, %s, how about some MUDSex?",GET_NAME(i));
 		do_say(ch,buf,0);
 	      } else {
-		sprintf(buf,"I'm much prettier than %s, don't you think?",GET_NAME(i));
+		SPRINTF(buf,"I'm much prettier than %s, don't you think?",GET_NAME(i));
 		do_say(ch,buf,0);
 	      }
 	    }
@@ -1947,7 +1947,7 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
       {
 	tmp_ch = (struct char_data *)FindAnyVictim(ch);
 	if (!IS_NPC(ch)) {
-	  sprintf(buf, "Party on, %s", GET_NAME(tmp_ch)); 
+	  SPRINTF(buf, "Party on, %s", GET_NAME(tmp_ch)); 
 	  do_say(ch, buf, 0);
 	  return(1);
 	} else {
@@ -1965,9 +1965,9 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
       for (i = character_list; i; i = i->next) {
 	if (!IS_NPC(i)) {
 	  if (number(0,30)==0) {
-	    sprintf(buf, "%s shout I love to MOSH!",GET_NAME(i));
+	    SPRINTF(buf, "%s shout I love to MOSH!",GET_NAME(i));
 	    do_force(ch, buf, 0);
-            sprintf(buf, "%s mosh", GET_NAME(i));
+            SPRINTF(buf, "%s mosh", GET_NAME(i));
             do_force(ch, buf, 0);
 	    do_restore(ch, GET_NAME(i), 0);
 	    return(TRUE);
@@ -1998,7 +1998,7 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
       for (i = character_list; i; i = i->next) {
 	if (!IS_NPC(i)) {
 	  if (number(0,30)==0) {
-	    sprintf(buf, "Top of the morning to you %s!", GET_NAME(i));
+	    SPRINTF(buf, "Top of the morning to you %s!", GET_NAME(i));
 	    do_shout(ch, buf, 0);
 	    return(TRUE);
 	  }
@@ -2009,7 +2009,7 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
       for (i = real_roomp(ch->in_room)->people; i; i= i->next_in_room) {
 	if (!IS_NPC(i)) {
 	  if (number(0,3)==0) {
-	    sprintf(buf, "Pardon me, %s, but are those bugle boy jeans you are wearing?", GET_NAME(i));
+	    SPRINTF(buf, "Pardon me, %s, but are those bugle boy jeans you are wearing?", GET_NAME(i));
 	    do_say(ch, buf, 0);
 	    return(TRUE);
 	  }
@@ -2020,7 +2020,7 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
       for (i = real_roomp(ch->in_room)->people; i; i= i->next_in_room) {
 	if (!IS_NPC(i)) {
 	  if (number(0,3)==0) {
-	    sprintf(buf, "Pardon me, %s, but do you have any Grey Poupon?", GET_NAME(i));
+	    SPRINTF(buf, "Pardon me, %s, but do you have any Grey Poupon?", GET_NAME(i));
 	    do_say(ch, buf, 0);
 	    return(TRUE);
 	  }
@@ -2092,7 +2092,7 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
       for (i = real_roomp(ch->in_room)->people; i; i=i->next_in_room) {
 	if (!IS_NPC(i)) {
 	  if (number(0,3)==0) {
-	    sprintf(buf, "%s, do you think I'm going bald?",GET_NAME(i));
+	    SPRINTF(buf, "%s, do you think I'm going bald?",GET_NAME(i));
 	    do_say(ch, buf, 0);
 	    return(TRUE);
 	  }
@@ -2110,7 +2110,7 @@ int puff(struct char_data *ch, int cmd, char * UNUSED(arg),
 	if (!IS_NPC(i)) {
 	  if (number(0,20) == 0) {
 	    if (i->in_room != NOWHERE) {
-	      sprintf(buf, "%s save", GET_NAME(i));
+	      SPRINTF(buf, "%s save", GET_NAME(i));
 	      do_force(ch, buf, 0);
 	      return(TRUE);
 	    }
@@ -2793,7 +2793,7 @@ int Ringwraith( struct char_data *ch, int cmd, char *arg, struct char_data *mob,
     wh->ringnumber = number(1,howmanyrings++);
   }
   
-  sprintf(buf, "%d.one ring.", (int)wh->ringnumber); /* where is this ring? */
+  SPRINTF(buf, "%d.one ring.", (int)wh->ringnumber); /* where is this ring? */
   if (NULL== (ring=get_obj_vis_world(ch, buf, NULL))) {
     /* there aren't as many one rings in the game as we thought */
     howmanyrings = 1;
@@ -3100,7 +3100,7 @@ int pet_shops(struct char_data *ch, int cmd, char *arg,
   if (cmd==59) { /* List */
     send_to_char("Available pets are:\n\r", ch);
     for(pet = real_roomp(pet_room)->people; pet; pet = pet->next_in_room) {
-      sprintf(buf, "%8d - %s\n\r", 24*GET_EXP(pet), pet->player.short_descr);
+      SPRINTF(buf, "%8d - %s\n\r", 24*GET_EXP(pet), pet->player.short_descr);
       send_to_char(buf, ch);
     }
     return(TRUE);
@@ -3127,11 +3127,11 @@ int pet_shops(struct char_data *ch, int cmd, char *arg,
     SET_BIT(pet->specials.affected_by, AFF_CHARM);
     
     if (*pet_name) {
-      sprintf(buf,"%s %s", pet->player.name, pet_name);
+      SPRINTF(buf,"%s %s", pet->player.name, pet_name);
       free(pet->player.name);
       pet->player.name = (char*)strdup(buf);		
       
-      sprintf(buf,"%sA small sign on a chain around the neck says 'My Name is %s'\n\r",
+      SPRINTF(buf,"%sA small sign on a chain around the neck says 'My Name is %s'\n\r",
 	      pet->player.description, pet_name);
       free(pet->player.description);
       pet->player.description = (char *)strdup(buf);
@@ -3226,10 +3226,10 @@ int Fountain(struct char_data *ch, int cmd, char *arg,
       return(FALSE);
     }
     
-    sprintf(buf,"You drink from the %s.\n\r",container);
+    SPRINTF(buf,"You drink from the %s.\n\r",container);
     send_to_char(buf, ch);
 
-    sprintf(buf,"$n drinks from the %s.",container);
+    SPRINTF(buf,"$n drinks from the %s.",container);
     act(buf, FALSE, ch, 0, 0, TO_ROOM);
 
 
@@ -3287,7 +3287,7 @@ int bank (struct char_data *ch, int cmd, char *arg,
       send_to_char("Thank you.\n\r",ch);
       GET_GOLD(ch) = GET_GOLD(ch) - money;
       GET_BANK(ch) = GET_BANK(ch) + money;
-      sprintf(buf,"Your balance is %d.\n\r", GET_BANK(ch));
+      SPRINTF(buf,"Your balance is %d.\n\r", GET_BANK(ch));
       send_to_char(buf, ch);
       return(TRUE);
     }
@@ -3310,12 +3310,12 @@ int bank (struct char_data *ch, int cmd, char *arg,
       send_to_char("Thank you.\n\r",ch);
       GET_GOLD(ch) = GET_GOLD(ch) + money;
       GET_BANK(ch) = GET_BANK(ch) - money;
-      sprintf(buf,"Your balance is %d.\n\r", GET_BANK(ch));
+      SPRINTF(buf,"Your balance is %d.\n\r", GET_BANK(ch));
       send_to_char(buf, ch);
       return(TRUE);
     }
   } else if (cmd == 221) {
-    sprintf(buf,"Your balance is %d.\n\r", GET_BANK(ch));
+    SPRINTF(buf,"Your balance is %d.\n\r", GET_BANK(ch));
     send_to_char(buf, ch);
     return(TRUE);
   }
@@ -3581,7 +3581,7 @@ int House(struct char_data *ch, int cmd, char *arg, struct room_data *rp, int ty
 
     cost.total_cost = 0;
 
-    sprintf(buf, "It will cost you %d coins per day\n\r", cost.total_cost);
+    SPRINTF(buf, "It will cost you %d coins per day\n\r", cost.total_cost);
     send_to_char(buf, ch);
 
     save_obj(ch, &cost,1);
@@ -4594,21 +4594,21 @@ int StatTeller(struct char_data *ch, int cmd, char * UNUSED(arg),
       switch(choice) {
       case 0:
 	if (HasClass(ch, CLASS_WARRIOR) && GET_STR(ch) == 18)
-	  sprintf(buf, "STR: %d/%d, WIS: %d, DEX: %d\n\r", GET_STR(ch), GET_ADD(ch), GET_WIS(ch), GET_DEX(ch));
+	  SPRINTF(buf, "STR: %d/%d, WIS: %d, DEX: %d\n\r", GET_STR(ch), GET_ADD(ch), GET_WIS(ch), GET_DEX(ch));
 	else
-	  sprintf(buf, "STR: %d, WIS: %d, DEX: %d\n\r", GET_STR(ch), GET_WIS(ch), GET_DEX(ch));
+	  SPRINTF(buf, "STR: %d, WIS: %d, DEX: %d\n\r", GET_STR(ch), GET_WIS(ch), GET_DEX(ch));
 	send_to_char(buf, ch);
 	break;
       case 1:
-	sprintf(buf, "INT: %d, DEX:  %d, CON: %d \n\r", GET_INT(ch), GET_DEX(ch), GET_CON(ch));
+	SPRINTF(buf, "INT: %d, DEX:  %d, CON: %d \n\r", GET_INT(ch), GET_DEX(ch), GET_CON(ch));
 	send_to_char(buf, ch);
 	break;
       case 2:
-	sprintf(buf, "CON: %d, INT: %d , WIS: %d \n\r", GET_CON(ch), GET_INT(ch), GET_WIS(ch));
+	SPRINTF(buf, "CON: %d, INT: %d , WIS: %d \n\r", GET_CON(ch), GET_INT(ch), GET_WIS(ch));
 	send_to_char(buf, ch);
 	break;
       case 3:
-	sprintf(buf, "DEX: %d, INT: %d, CHR: %d \n\r", GET_DEX(ch), GET_INT(ch), GET_CHR(ch));
+	SPRINTF(buf, "DEX: %d, INT: %d, CHR: %d \n\r", GET_DEX(ch), GET_INT(ch), GET_CHR(ch));
 	send_to_char(buf, ch);
 	break;
       default:
@@ -4661,15 +4661,15 @@ int StatTeller(struct char_data *ch, int cmd, char *arg, struct char_data *mob, 
       choice = number(0,2);
       switch(choice) {
       case 0:
-	sprintf(buf, "STR: %d, WIS: %d, DEX: %d\n\r", GET_STR(ch), GET_WIS(ch), GET_DEX(ch));
+	SPRINTF(buf, "STR: %d, WIS: %d, DEX: %d\n\r", GET_STR(ch), GET_WIS(ch), GET_DEX(ch));
 	send_to_char(buf, ch);
 	break;
       case 1:
-	sprintf(buf, "INT: %d, DEX:  %d, CON: %d \n\r", GET_INT(ch), GET_DEX(ch), GET_CON(ch));
+	SPRINTF(buf, "INT: %d, DEX:  %d, CON: %d \n\r", GET_INT(ch), GET_DEX(ch), GET_CON(ch));
 	send_to_char(buf, ch);
 	break;
       case 2:
-	sprintf(buf, "CON: %d, INT: %d , WIS: %d \n\r", GET_CON(ch), GET_INT(ch), GET_WIS(ch));
+	SPRINTF(buf, "CON: %d, INT: %d , WIS: %d \n\r", GET_CON(ch), GET_INT(ch), GET_WIS(ch));
 	send_to_char(buf, ch);
 	break;
       default:
@@ -4714,7 +4714,7 @@ void ThrowChar(struct char_data *ch, struct char_data *v, int dir)
     if (v->specials.fighting) {
       stop_fighting(v);
     }
-    sprintf(buf, "%s picks you up and throws you %s\n\r", 
+    SPRINTF(buf, "%s picks you up and throws you %s\n\r", 
 	    ch->player.short_descr, dirs[dir]);
     send_to_char(buf,v);
     or = v->in_room;
@@ -4845,7 +4845,7 @@ int Tyrannosaurus_swallower(struct char_data *ch, int cmd, char * UNUSED(arg),
 	  kill target:
 	  */
 	GET_HIT(targ) = 0;
-	sprintf(buf, "%s killed by being swallowed whole", GET_NAME(targ));
+	SPRINTF(buf, "%s killed by being swallowed whole", GET_NAME(targ));
 	log_msg(buf);
 	die(targ);
 	/*
@@ -5037,7 +5037,7 @@ int nodrop(struct char_data *ch, int cmd, char *arg,
 	  FALSE, ch, obj, 0, TO_CHAR);
       act("$n drops $p, and it shatters!", FALSE, ch, obj, 0, TO_ROOM);
       i = read_object(30, VIRTUAL);
-      sprintf(buf, "Scraps from %s lie in a pile here.",
+      SPRINTF(buf, "Scraps from %s lie in a pile here.",
 	      obj->short_description);
       i->description = (char *)strdup(buf);
       obj_to_room(i, ch->in_room);
@@ -5571,7 +5571,7 @@ int trapper(struct char_data *ch, int cmd, char * UNUSED(arg),
       act("$n has suffocated inside $N!",
 	  FALSE, ch->specials.fighting, 0, ch, TO_ROOM);
       act("$n is dead!", FALSE, ch->specials.fighting, 0, ch, TO_ROOM);
-      sprintf(buf, "%s has suffocated to death.", 
+      SPRINTF(buf, "%s has suffocated to death.", 
 	      GET_NAME(ch->specials.fighting));
       log_msg(buf);
       die(ch->specials.fighting);
@@ -5606,7 +5606,7 @@ int trogcook(struct char_data *ch, int cmd, char * UNUSED(arg),
   if (corpse) {
       do_get(ch, "corpse", -1);
       act("$n cackles 'Into the soup with it!'", FALSE, ch, 0, 0, TO_ROOM);
-      sprintf(buf, "put corpse pot");
+      SPRINTF(buf, "put corpse pot");
       command_interpreter(ch, buf);
       return(TRUE);
     }
@@ -5990,7 +5990,7 @@ int Valik( struct char_data *ch, int cmd, char *arg, struct char_data *mob, int 
       else {
 	if(!(strcmp(arg," What is the quest of the Rhyodin?")))
 	  for(i = 0 ; i < 9 ; ++i) {
-	    sprintf(buf,"%s %s",GET_NAME(ch),quest_intro[i]);
+	    SPRINTF(buf,"%s %s",GET_NAME(ch),quest_intro[i]);
 	    do_tell(vict,buf,19);
 	  }
 	return(TRUE);
@@ -6057,7 +6057,7 @@ int Valik( struct char_data *ch, int cmd, char *arg, struct char_data *mob, int 
 	char_from_room(ch);
 	char_to_room(ch,Med_Chambers);
 	act("Reality warps and spins around you!",FALSE,ch,0,0,TO_ROOM);
-	sprintf(buf, "close mahogany");
+	SPRINTF(buf, "close mahogany");
 	command_interpreter(ch, buf);
 	do_rest(ch, "", -1);
 	ch->generic = Valik_Meditating;

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -358,7 +358,7 @@ int Summoner(struct char_data *ch, int cmd, char * UNUSED(arg),
           if (i->op_ch) {  /* if there is a char_ptr */
 	    targ = i->op_ch;
 	    if (IS_PC(targ)) {
-	      sprintf(buf, "You hate %s\n\r", targ->player.name);
+	      SPRINTF(buf, "You hate %s\n\r", targ->player.name);
 	      send_to_char(buf, ch);
 	      break;
 	    }
@@ -389,7 +389,7 @@ int Summoner(struct char_data *ch, int cmd, char * UNUSED(arg),
       }
       if (targ->in_room == ch->in_room) {
 	 if (NumCharmedFollowersInRoom(ch) > 0) {
-	   sprintf(buf, "followers kill %s", GET_NAME(targ));
+	   SPRINTF(buf, "followers kill %s", GET_NAME(targ));
 	   do_order(ch, buf, 0);
 	 }
          hit(ch, targ, 0);
@@ -487,7 +487,7 @@ int jive_box(struct char_data *ch, int cmd, char *arg,
                  break;
        case 19:  half_chop(arg, tmp, buf);
                  invert(buf, buf2);
-                 sprintf(buf3, "%s %s", tmp, buf);
+                 SPRINTF(buf3, "%s %s", tmp, buf);
                  do_tell(ch, buf3, cmd);
                  return(TRUE);
                  break;
@@ -679,11 +679,11 @@ int magic_user(struct char_data *ch, int cmd, char *arg, struct char_data *mob, 
 	char buf[200];
 
 	if (!vict->specials.fighting) {
-	  sprintf(buf, "%s kill %s", 
+	  SPRINTF(buf, "%s kill %s", 
 		  GET_NAME(vict), GET_NAME(ch->specials.fighting));
 	  do_order(ch, buf, 0);
 	} else {
-	  sprintf(buf, "%s remove all", GET_NAME(vict));
+	  SPRINTF(buf, "%s remove all", GET_NAME(vict));
 	  do_order(ch, buf, 0);
 	}
       }
@@ -1160,7 +1160,7 @@ int Teacher(struct char_data *ch, int cmd, char *arg,
   case TAUGHT_BY_ETTIN:
     break;
   default:
-    sprintf(buf,"Teacher() attempted to be called with %d(mob#) as teacher.",
+    SPRINTF(buf,"Teacher() attempted to be called with %d(mob#) as teacher.",
 	    teacher);
     log_msg(buf);
     return(FALSE);
@@ -1174,7 +1174,7 @@ int Teacher(struct char_data *ch, int cmd, char *arg,
       send_to_char("You can practice any of these skills:\n\r", ch);
       for(i=0; *spells[i] != '\n'; i++) {
         if (skill_info[i+1].taught_by & teacher) {
-          sprintf(buf, "%-30s %s\n\r", spells[i],
+          SPRINTF(buf, "%-30s %s\n\r", spells[i],
                   how_good(ch->skills[i+1].learned));
           send_to_char(buf, ch);
         }
@@ -1182,7 +1182,7 @@ int Teacher(struct char_data *ch, int cmd, char *arg,
       return(TRUE);
     } else {
       number = old_search_block(arg,0,strlen(arg),spells,FALSE);
-      sprintf(buf, "The %s says ",say_str);
+      SPRINTF(buf, "The %s says ",say_str);
       send_to_char (buf,ch);
       if (number == -1) {
         send_to_char("'I do not know of this skill.'\n\r", ch);
@@ -1249,7 +1249,7 @@ int Teacher(struct char_data *ch, int cmd, char *arg,
       return(TRUE);
     }
 
-    sprintf(buf,"\'That will be %d coins.'\n\rThe %s says ",
+    SPRINTF(buf,"\'That will be %d coins.'\n\rThe %s says ",
 	    charge,say_str);
     
     send_to_char(buf,ch);
@@ -1381,7 +1381,7 @@ int RepairGuy( struct char_data *ch, int cmd, char *arg, struct char_data *mob, 
 	    act("$N decides $S doesn't like you.", FALSE, ch, 0, vict,TO_CHAR);
 	    send_to_char("You are charged double!\n\r",ch);
 	  }
-	  sprintf(buf, "You give $N %d coins.",cost);
+	  SPRINTF(buf, "You give $N %d coins.",cost);
 	  act(buf,TRUE,ch,0,vict,TO_CHAR);
 	  act("$n gives some money to $N.",TRUE,ch,obj,vict,TO_ROOM);
 
@@ -1463,7 +1463,7 @@ int RepairGuy( struct char_data *ch, int cmd, char *arg, struct char_data *mob, 
 	} else {
 	  GET_GOLD(ch) -= cost;
 	  
-	  sprintf(buf, "You give $N %d coins.",cost);
+	  SPRINTF(buf, "You give $N %d coins.",cost);
 	  act(buf,TRUE,ch,0,vict,TO_CHAR);
 	  act("$n gives some money to $N.",TRUE,ch,obj,vict,TO_ROOM);
 	  
@@ -2121,19 +2121,19 @@ void  Submit(struct char_data *ch, struct char_data *t)
 
   switch(number(1,5)) {
   case 1:
-    sprintf(buf, "bow %s", GET_NAME(t));
+    SPRINTF(buf, "bow %s", GET_NAME(t));
     command_interpreter(ch, buf);
     break;
   case 2:
-    sprintf(buf, "smile %s", GET_NAME(t));
+    SPRINTF(buf, "smile %s", GET_NAME(t));
     command_interpreter(ch, buf);
     break;
   case 3:
-    sprintf(buf, "wink %s", GET_NAME(t));
+    SPRINTF(buf, "wink %s", GET_NAME(t));
     command_interpreter(ch, buf);
     break;
   case 4:
-    sprintf(buf, "wave %s", GET_NAME(t));
+    SPRINTF(buf, "wave %s", GET_NAME(t));
     command_interpreter(ch, buf);
     break;
   default:
@@ -2165,9 +2165,9 @@ void  SayHello(struct char_data *ch, struct char_data *t)
     break;
   case 4:
     if (t->player.sex == SEX_FEMALE)
-      sprintf(buf, "Make way!  Make way for the lady %s!", GET_NAME(t));
+      SPRINTF(buf, "Make way!  Make way for the lady %s!", GET_NAME(t));
     else
-      sprintf(buf, "Make way!  Make way for the lord %s!", GET_NAME(t));
+      SPRINTF(buf, "Make way!  Make way for the lord %s!", GET_NAME(t));
     do_say(ch, buf, 0);
     break;
   case 5:
@@ -2184,13 +2184,13 @@ void  SayHello(struct char_data *ch, struct char_data *t)
     break;
   case 9:
     if (time_info.hours > 6 && time_info.hours < 12) 
-      sprintf(buf, "Good morning, %s", GET_NAME(t));
+      SPRINTF(buf, "Good morning, %s", GET_NAME(t));
     else if (time_info.hours >=12 && time_info.hours < 20)
-      sprintf(buf, "Good afternoon, %s", GET_NAME(t));
+      SPRINTF(buf, "Good afternoon, %s", GET_NAME(t));
     else if (time_info.hours >= 20 && time_info.hours <= 24)
-      sprintf(buf, "Good evening, %s", GET_NAME(t));
+      SPRINTF(buf, "Good evening, %s", GET_NAME(t));
     else 
-      sprintf(buf, "Up for a midnight stroll, %s?\n", GET_NAME(t));
+      SPRINTF(buf, "Up for a midnight stroll, %s?\n", GET_NAME(t));
     do_say(ch, buf, 0);
     break;
   case 10:{
@@ -2205,21 +2205,21 @@ void  SayHello(struct char_data *ch, struct char_data *t)
     
     switch(weather_info.sky) {
     case SKY_CLOUDLESS:
-      sprintf(buf, "Lovely weather we're having this %s, isn't it, %s.",
+      SPRINTF(buf, "Lovely weather we're having this %s, isn't it, %s.",
 	      buf2, GET_NAME(t));
     case SKY_CLOUDY:
-      sprintf(buf, "Nice %s to go for a walk, %s.", buf2, GET_NAME(t));
+      SPRINTF(buf, "Nice %s to go for a walk, %s.", buf2, GET_NAME(t));
       break;
     case SKY_RAINING:
-      sprintf(buf, "I hope %s's rain clears up.. don't you %s?", buf2,
+      SPRINTF(buf, "I hope %s's rain clears up.. don't you %s?", buf2,
 	      GET_NAME(t));
       break;
     case SKY_LIGHTNING:
-      sprintf(buf, "How can you be out on such a miserable %s, %s!",
+      SPRINTF(buf, "How can you be out on such a miserable %s, %s!",
 	      buf2, GET_NAME(t));
       break;
     default:
-      sprintf(buf, "Such a pleasant %s, don't you think?", buf2);
+      SPRINTF(buf, "Such a pleasant %s, don't you think?", buf2);
       break;
     }
     do_say(ch, buf, 0);
@@ -2572,7 +2572,7 @@ int BreathWeapon(struct char_data *ch, int cmd, char * UNUSED(arg),
       ;
     
     if (scan->vnum < 0) {
-      sprintf(buf, "monster %s tries to breath, but isn't listed.",
+      SPRINTF(buf, "monster %s tries to breath, but isn't listed.",
 	      ch->player.short_descr);
       log_msg(buf);
       return FALSE;
@@ -2582,7 +2582,7 @@ int BreathWeapon(struct char_data *ch, int cmd, char * UNUSED(arg),
       ;
     
     if (count<1) {
-      sprintf(buf, "monster %s has no breath weapons",
+      SPRINTF(buf, "monster %s has no breath weapons",
 	      ch->player.short_descr);
       log_msg(buf);
       return FALSE;
@@ -3403,16 +3403,16 @@ int DragonHunterLeader(struct char_data *ch, int UNUSED(cmd),
                 for(i = real_roomp(ch->in_room)->people; i; i = i->next_in_room) {
                    if(IS_MOB(i) && (mob_index[i->nr].virtual == WHO_TO_CALL)) {
                      (*mob_index[i->nr].func)(i, 0, "", ch, EVENT_FOLLOW);
-                     sprintf(buf, "%d.%s", count, GET_NAME(i));
+                     SPRINTF(buf, "%d.%s", count, GET_NAME(i));
                      do_group(ch, buf, 0);
                      count++;
 		   }
                    else if((i->master) && (i->master == ch) && (GetMaxLevel(i) > 10)) {
-                     sprintf(buf, "%s", GET_NAME(i));
+                     SPRINTF(buf, "%s", GET_NAME(i));
                      do_group(ch, buf, 0);
 		   }
                   else if((i->master) && (i->master == ch)) {
-                     sprintf(buf, "%s You're too little! Get Lost!", GET_NAME(i));
+                     SPRINTF(buf, "%s You're too little! Get Lost!", GET_NAME(i));
                      do_tell(ch, buf, 0);
 		   }
 		 }
@@ -3581,7 +3581,7 @@ int SlotMachine(struct char_data *ch, int cmd, char * UNUSED(arg),
     case 5:
     case 6:
     case 7:  i[c] = 0;
-             sprintf(buf, "Slot %d: Lemon\n\r", c);
+             SPRINTF(buf, "Slot %d: Lemon\n\r", c);
              send_to_char(buf, ch);
                  break;
     case 8:
@@ -3591,7 +3591,7 @@ int SlotMachine(struct char_data *ch, int cmd, char * UNUSED(arg),
     case 12:
     case 13:
     case 14: i[c] = 1;
-             sprintf(buf, "Slot %d: Orange\n\r", c);
+             SPRINTF(buf, "Slot %d: Orange\n\r", c);
              send_to_char(buf, ch);
                  break;
     case 15:
@@ -3600,7 +3600,7 @@ int SlotMachine(struct char_data *ch, int cmd, char * UNUSED(arg),
     case 18:
     case 19:
     case 20: i[c] = 2;
-             sprintf(buf, "Slot %d: Banana\n\r", c);
+             SPRINTF(buf, "Slot %d: Banana\n\r", c);
              send_to_char(buf, ch);
                  break;
     case 21:
@@ -3608,16 +3608,16 @@ int SlotMachine(struct char_data *ch, int cmd, char * UNUSED(arg),
     case 23:
     case 24:
     case 25: i[c] = 3;
-             sprintf(buf, "Slot %d: Peach\n\r", c);
+             SPRINTF(buf, "Slot %d: Peach\n\r", c);
              send_to_char(buf, ch);
                  break;
     case 26:
     case 27: i[c] = 4;
-             sprintf(buf, "Slot %d: Bar\n\r", c);
+             SPRINTF(buf, "Slot %d: Bar\n\r", c);
              send_to_char(buf, ch);
                  break;
     case 28: i[c] = 5;
-             sprintf(buf, "Slot %d: Gold\n\r", c);
+             SPRINTF(buf, "Slot %d: Gold\n\r", c);
              send_to_char(buf, ch);
                  break;
     }
@@ -3646,7 +3646,7 @@ int SlotMachine(struct char_data *ch, int cmd, char * UNUSED(arg),
     if(ind > jackpot)
       ind = jackpot; /* Can only win as much as there is */
  
-   sprintf(buf, "You have won %d coins!\n\r", ind);
+   SPRINTF(buf, "You have won %d coins!\n\r", ind);
    send_to_char(buf, ch);
  
    GET_GOLD(ch) += ind;

--- a/src/spec_procs3.c
+++ b/src/spec_procs3.c
@@ -817,7 +817,7 @@ int turbo_lift(struct char_data *ch, int cmd, char *arg, struct room_data *rp,
 
   send_to_room("There is a small sensation of motion.\n\r",ch->in_room);
   send_to_room("The lights flicker for a moment.\n\r", ch->in_room);
-  sprintf(buf,"\n\rThe doors open to the %s.\n\r",dirs[i]);
+  SPRINTF(buf,"\n\rThe doors open to the %s.\n\r",dirs[i]);
   send_to_room(buf,ch->in_room);
 
   return(TRUE);

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -765,8 +765,8 @@ void say_spell( struct char_data *ch, int si )
   
   offs = 0;
   if(si == SPELL_FIREBALL && GET_SEX(ch) == SEX_MALE) {
-    sprintf(buf2,"$n utters the words, 'Hmm hmmhmm, heh heh, FIRE! FIRE! FIRE!'");
-    sprintf(buf, "$n utters the words, 'Hmm hmmhmm, heh heh, FIRE! FIRE! FIRE!'");
+    SPRINTF(buf2,"$n utters the words, 'Hmm hmmhmm, heh heh, FIRE! FIRE! FIRE!'");
+    SPRINTF(buf, "$n utters the words, 'Hmm hmmhmm, heh heh, FIRE! FIRE! FIRE!'");
   } else {
   
     while(*(splwd+offs)) {
@@ -780,8 +780,8 @@ void say_spell( struct char_data *ch, int si )
 	}
     }
     
-    sprintf(buf2,"$n utters the words, '%s'", buf);
-    sprintf(buf, "$n utters the words, '%s'", spells[si-1]);
+    SPRINTF(buf2,"$n utters the words, '%s'", buf);
+    SPRINTF(buf, "$n utters the words, '%s'", spells[si-1]);
   }
   for(temp_char = real_roomp(ch->in_room)->people;
       temp_char;
@@ -1924,7 +1924,7 @@ int check_falling( struct char_data *ch)
 
 	if (!IS_IMMORTAL(ch)) {
 	  GET_HIT(ch) = 0;
-	  sprintf(buf, "%s has fallen to death", GET_NAME(ch));
+	  SPRINTF(buf, "%s has fallen to death", GET_NAME(ch));
 	  log_msg(buf);
 	if (!ch->desc)
 	  GET_GOLD(ch) = 0;
@@ -1993,7 +1993,7 @@ int check_falling( struct char_data *ch)
 
 	if (!IS_IMMORTAL(ch)) {
 	  GET_HIT(ch) = 0;
-	  sprintf(buf, "%s has fallen to death", GET_NAME(ch));
+	  SPRINTF(buf, "%s has fallen to death", GET_NAME(ch));
 	  log_msg(buf);
 	if (!ch->desc)
 	  GET_GOLD(ch) = 0;
@@ -2054,7 +2054,7 @@ void check_drowning( struct char_data *ch)
       GET_MOVE(ch) -= number(10,50);
       update_pos(ch);
       if (GET_HIT(ch) < -10) {
-	sprintf(buf, "%s killed by drowning", GET_NAME(ch));
+	SPRINTF(buf, "%s killed by drowning", GET_NAME(ch));
 	log_msg(buf);
 	if (!ch->desc)
 	  GET_GOLD(ch) = 0;

--- a/src/spells2.c
+++ b/src/spells2.c
@@ -1012,7 +1012,7 @@ void cast_curse(byte level, struct char_data *ch, char * UNUSED(arg), int type,
 	spell_curse(level,ch,tar_ch,0);
     break;
     default : 
-      sprintf(buf,"Serious screw up in curse! Char = %s.",ch->player.name);
+      SPRINTF(buf,"Serious screw up in curse! Char = %s.",ch->player.name);
       log_msg(buf);
     break;
   }
@@ -1610,16 +1610,16 @@ void cast_ventriloquate(byte UNUSED(level), struct char_data *ch, char *arg,
 	}
 	for(; *arg && (*arg == ' '); arg++);
 	if (tar_obj) {
-		sprintf(buf1, "The %s says '%s'\n\r", fname(tar_obj->name), arg);
-		sprintf(buf2, "Someone makes it sound like the %s says '%s'.\n\r",
+		SPRINTF(buf1, "The %s says '%s'\n\r", fname(tar_obj->name), arg);
+		SPRINTF(buf2, "Someone makes it sound like the %s says '%s'.\n\r",
 		  fname(tar_obj->name), arg);
 	}	else {
-		sprintf(buf1, "%s says '%s'\n\r", GET_NAME(tar_ch), arg);
-		sprintf(buf2, "Someone makes it sound like %s says '%s'\n\r",
+		SPRINTF(buf1, "%s says '%s'\n\r", GET_NAME(tar_ch), arg);
+		SPRINTF(buf2, "Someone makes it sound like %s says '%s'\n\r",
 		  GET_NAME(tar_ch), arg);
 	}
 
-	sprintf(buf3, "Someone says, '%s'\n\r", arg);
+	SPRINTF(buf3, "Someone says, '%s'\n\r", arg);
 
 	for (tmp_ch = real_roomp(ch->in_room)->people; tmp_ch;
 	  tmp_ch = tmp_ch->next_in_room) {
@@ -1792,7 +1792,7 @@ void cast_dragon_breath(byte level, struct char_data *ch, char * UNUSED(arg),
   if (scan->vnum==0) {
     char	buf[MAX_STRING_LENGTH];
     send_to_char("Hey, this potion isn't in my list!\n\r", ch);
-    sprintf(buf,"unlisted breath potion %s %d", potion->short_description,
+    SPRINTF(buf,"unlisted breath potion %s %d", potion->short_description,
 	    obj_index[potion->item_number].virtual);
     log_msg(buf);
     return;
@@ -2821,7 +2821,7 @@ void cast_familiar(byte level, struct char_data *ch, char *arg, int type,
     spell_familiar(level, ch, &tar_ch, 0);
 
     if (tar_ch) {
-      sprintf(buf, "%s %s", GET_NAME(tar_ch), fname(arg));
+      SPRINTF(buf, "%s %s", GET_NAME(tar_ch), fname(arg));
       free(GET_NAME(tar_ch));
       GET_NAME(tar_ch) = (char *)malloc(strlen(buf)+1);
       strcpy(GET_NAME(tar_ch), buf);
@@ -2908,7 +2908,7 @@ void cast_command(byte UNUSED(level), struct char_data *ch, char *arg,
 	!saves_spell(tar_ch, SAVING_PARA)) {
 
       if (strcmp(p, "quit")) {
-	sprintf(buf, "$n has commanded you to '%s'.", p);
+	SPRINTF(buf, "$n has commanded you to '%s'.", p);
 	act(buf, FALSE, ch, 0, tar_ch, TO_VICT);
 	send_to_char("Ok.\n\r", ch);
 	command_interpreter(tar_ch, p);
@@ -2916,7 +2916,7 @@ void cast_command(byte UNUSED(level), struct char_data *ch, char *arg,
       }
     }
 
-    sprintf(buf, "$n just tried to command you to '%s'.", p);
+    SPRINTF(buf, "$n just tried to command you to '%s'.", p);
     act(buf, FALSE, ch, 0, tar_ch, TO_VICT);
 
     if (!IS_PC(tar_ch))
@@ -3652,9 +3652,9 @@ void cast_sending(byte UNUSED(level), struct char_data *ch, char *arg,
   switch(type) {
   case SPELL_TYPE_SPELL:
     for (;*arg == ' ';arg++);
-    sprintf(buf, "$n sends you a mystic message: %s", arg);
+    SPRINTF(buf, "$n sends you a mystic message: %s", arg);
     act(buf, TRUE, ch, 0, tar_ch, TO_VICT);
-    sprintf(buf, "You send $N the message: %s", arg);
+    SPRINTF(buf, "You send $N the message: %s", arg);
     act(buf, TRUE, ch, 0, tar_ch, TO_CHAR);
     break;
   default:

--- a/src/test.act.wizard.c
+++ b/src/test.act.wizard.c
@@ -6,98 +6,98 @@ void dsearch(char *, char *);
 
 Test(act_wizard, dsearch_simple) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone appears!");
+  SPRINTF(arg, "Someone appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(dst, "Someone appears!");
 }
 
 Test(act_wizard, dsearch_simple_tilde) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~ appears!");
+  SPRINTF(arg, "Someone ~ appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(dst, "Someone appears!");
 }
 
 Test(act_wizard, dsearch_tilde_at_end) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone appears!~");
+  SPRINTF(arg, "Someone appears!~");
   dsearch(arg, dst);
   cr_assert_str_eq(dst, "Someone appears!");
 }
 
 Test(act_wizard, dsearch_tilde_N_simple) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~N appears!");
+  SPRINTF(arg, "Someone ~N appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(dst, "Someone $n appears!");
 }
 
 Test(act_wizard, dsearch_tilde_H_simple) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~H appears!");
+  SPRINTF(arg, "Someone ~H appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(dst, "Someone $s appears!");
 }
 
 Test(act_wizard, dsearch_double_tilde) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~~ appears!");
+  SPRINTF(arg, "Someone ~~ appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(dst, "Someone  appears!");
 }
 
 Test(act_wizard, dsearch_double_substitution) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~N~N appears!");
+  SPRINTF(arg, "Someone ~N~N appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(dst, "Someone $n$n appears!");
 }
 
 Test(act_wizard, dsearch_simple_arg) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone appears!");
+  SPRINTF(arg, "Someone appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(arg, "Someone appears!");
 }
 
 Test(act_wizard, dsearch_simple_tilde_arg) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~ appears!");
+  SPRINTF(arg, "Someone ~ appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(arg, "Someone appears!");
 }
 
 Test(act_wizard, dsearch_tilde_at_end_arg) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone appears!~");
+  SPRINTF(arg, "Someone appears!~");
   dsearch(arg, dst);
   cr_assert_str_eq(arg, "Someone appears!");
 }
 
 Test(act_wizard, dsearch_tilde_N_simple_arg) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~N appears!");
+  SPRINTF(arg, "Someone ~N appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(arg, "Someone $n appears!");
 }
 
 Test(act_wizard, dsearch_tilde_H_simple_arg) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~H appears!");
+  SPRINTF(arg, "Someone ~H appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(arg, "Someone $s appears!");
 }
 
 Test(act_wizard, dsearch_double_tilde_arg) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~~ appears!");
+  SPRINTF(arg, "Someone ~~ appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(arg, "Someone  appears!");
 }
 
 Test(act_wizard, dsearch_double_substitution_arg) {
   char arg[255], dst[255];
-  sprintf(arg, "Someone ~N~N appears!");
+  SPRINTF(arg, "Someone ~N~N appears!");
   dsearch(arg, dst);
   cr_assert_str_eq(arg, "Someone $n$n appears!");
 }

--- a/src/test.act.wizard.c
+++ b/src/test.act.wizard.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <criterion/criterion.h>
 #include "config.h"
+#include "utils.h"
 
 void dsearch(char *, char *);
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -198,10 +198,10 @@ void Zwrite (FILE *fp, char cmd, int tf, int arg1, int arg2, int arg3,
    char buf[100];
 
    if (*desc) {
-     sprintf(buf, "%c %d %d %d %d   ; %s\n", cmd, tf, arg1, arg2, arg3, desc);
+     SPRINTF(buf, "%c %d %d %d %d   ; %s\n", cmd, tf, arg1, arg2, arg3, desc);
      fputs(buf, fp);
    } else {
-     sprintf(buf, "%c %d %d %d %d\n", cmd, tf, arg1, arg2, arg3); 
+     SPRINTF(buf, "%c %d %d %d %d\n", cmd, tf, arg1, arg2, arg3); 
      fputs(buf, fp);
    }
 }
@@ -226,7 +226,7 @@ FILE *MakeZoneFile( struct char_data *c)
   char buf[256];
   FILE *fp;
 
-  sprintf(buf, "zone/%s.zon", GET_NAME(c));
+  SPRINTF(buf, "zone/%s.zon", GET_NAME(c));
 
   if ((fp = fopen(buf, "w")) != NULL)
     return(fp);
@@ -360,7 +360,7 @@ void log_sev(char *str,int sev)
   
   
   if (str)
-    sprintf(buf,"/* %s */\n\r",str);
+    SPRINTF(buf,"/* %s */\n\r",str);
   for (i = descriptor_list; i; i = i->next)
     if ((!i->connected) && (GetMaxLevel(i->character)>=LOW_IMMORTAL) &&
 	(i->character->specials.sev <= sev) &&
@@ -695,7 +695,7 @@ int sab;
 char buf[200];
 
    if (exp_flags > 100) { 
-     sprintf(buf, "Exp flags on %s are > 100 (%d)", GET_NAME(mob), exp_flags);
+     SPRINTF(buf, "Exp flags on %s are > 100 (%d)", GET_NAME(mob), exp_flags);
      log_msg(buf);
    }
 
@@ -989,7 +989,7 @@ void down_river( int pulse )
 			    IS_SET(ch->specials.act, PLR_NOHASSLE)) {
 			   send_to_char("The waters swirl beneath your feet.\n\r",ch);
 			 } else {
-			   sprintf(buf, "You drift %s...\n\r", dirs[rd]);
+			   SPRINTF(buf, "You drift %s...\n\r", dirs[rd]);
 			   send_to_char(buf,ch);
 			   if (RIDDEN(ch))
 			     send_to_char(buf,RIDDEN(ch));
@@ -1034,7 +1034,7 @@ void RoomSave(struct char_data *ch, int start, int end)
    struct room_direction_data	*rdd;
 
 
-   sprintf(fn, "rooms/%s", ch->player.name);
+   SPRINTF(fn, "rooms/%s", ch->player.name);
    if ((fp = fopen(fn,"w")) == NULL) {
      send_to_char("Can't write to disk now..try later \n\r",ch);
      return;
@@ -1226,7 +1226,7 @@ void RoomLoad( struct char_data *ch, int start, int end)
   char buf[80];
   struct room_data *rp, dummy;
 
-  sprintf(buf, "rooms/%s", ch->player.name);
+  SPRINTF(buf, "rooms/%s", ch->player.name);
   if ((fp = fopen(buf,"r")) == NULL) {
     send_to_char("You don't appear to have an area...\n\r",ch);
     return;
@@ -1624,7 +1624,7 @@ return;
    ch->old_room = ch->in_room;
 #if 0
     if (GetMaxLevel(tch) >= IMMORTAL) {
-        sprintf(buf, ">>%s is hunting you from %s\n\r", 
+        SPRINTF(buf, ">>%s is hunting you from %s\n\r", 
        	   (ch->player.short_descr[0]?ch->player.short_descr:"(null)"),
        	   (real_roomp(ch->in_room)->name[0]?real_roomp(ch->in_room)->name:"(null)"));
         send_to_char(buf, tch);
@@ -2149,7 +2149,7 @@ void RiverPulseStuff(int pulse)
 			if (ch->specials.fighting) {
 			  stop_fighting(ch);
 			}
-			sprintf(buf, "You drift %s...\n\r", dirs[rd]);
+			SPRINTF(buf, "You drift %s...\n\r", dirs[rd]);
 			send_to_char(buf,ch);
 			if (RIDDEN(ch))
 			  send_to_char(buf,RIDDEN(ch));
@@ -2205,7 +2205,7 @@ void RiverPulseStuff(int pulse)
 	    /*
 	     * snore 
 	     */	 
-	    sprintf(buffer, "%s snores loudly.\n\r", 
+	    SPRINTF(buffer, "%s snores loudly.\n\r", 
 		    ch->player.short_descr);
 	    MakeNoise(ch->in_room, buffer, 
 		      "You hear a loud snore nearby.\n\r");

--- a/src/utils.h
+++ b/src/utils.h
@@ -299,7 +299,7 @@
 #endif
 
 #define SPRINTF(str, ...)                       \
-  (sizeof(str) > 8 ?                            \
+  (sizeof(str) > SIZEOF_VOID_P ?                \
    snprintf(str, sizeof(str), __VA_ARGS__) :    \
    sprintf(str, __VA_ARGS__))
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,8 +9,6 @@
 
 #include "config.h"
 
-int CAN_SEE(struct char_data *s, struct char_data *o);
-
 #if DEBUG
 
 #define free(obj) fprintf(stderr, "freeing %d\n", sizeof(*obj));\
@@ -261,8 +259,6 @@ int CAN_SEE(struct char_data *s, struct char_data *o);
 			isname("corpse", (obj)->name))
 
 #define EXIT(ch, door)  (real_roomp((ch)->in_room)->dir_option[door])
-
-int exit_ok(struct room_direction_data *, struct room_data **);
 
 #define CAN_GO(ch, door) (EXIT(ch,door)&&real_roomp(EXIT(ch,door)->to_room) \
                           && !IS_SET(EXIT(ch, door)->exit_info, EX_CLOSED))

--- a/src/utils.h
+++ b/src/utils.h
@@ -301,3 +301,12 @@ int exit_ok(struct room_direction_data *, struct room_data **);
 			RACE_MFLAYER)
 
 #endif
+
+#define SPRINTF(str, ...)                       \
+  (sizeof(str) > 8 ?                            \
+   snprintf(str, sizeof(str), __VA_ARGS__) :    \
+   sprintf(str, __VA_ARGS__))
+
+#define SAPPENDF(str, ...)                                          \
+  snprintf(str+strlen(str), sizeof(str)-strlen(str) - 1, __VA_ARGS__)
+

--- a/src/weather.c
+++ b/src/weather.c
@@ -67,7 +67,7 @@ void another_hour(int mode)
 	strcpy(moon, "new");
       }
       switch_light(MOON_RISE);
-      sprintf(buf,"The %s moon slowly rises from the western horizon.\n\r",moon);
+      SPRINTF(buf,"The %s moon slowly rises from the western horizon.\n\r",moon);
       send_to_outdoor(buf);
       if((moontype > 16) && (moontype < 22)) {
 	gLightLevel++;   /* brighter during these moons */


### PR DESCRIPTION
Mostly replace `sprintf` with `snprintf`.

The macro replaces them when the dest buf looks like a char array. If it doesn't, it falls back to `sprintf`. Maybe that is too dicey?
