### PR TITLE
Fix parsing bug for numbered items.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,8 @@ sillymud_SOURCES = $(common_sources) main.c
 
 # unit tests
 check_PROGRAMS = tests
-tests_SOURCES = $(common_sources) test.act.wizard.c test.spell_parser.c
+tests_SOURCES = $(common_sources) test.act.wizard.c test.spell_parser.c \
+	test.handler.c
 tests_LDADD = -lcriterion
 TESTS = tests
 

--- a/src/act.info.c
+++ b/src/act.info.c
@@ -2176,7 +2176,7 @@ void do_where(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   
   if (isdigit(*name)) {
     nameonly = name;
-    count = number = get_number(&nameonly);
+    count = number = get_number(nameonly);
   } else {
     count = number = 0;
   }

--- a/src/handler.c
+++ b/src/handler.c
@@ -952,24 +952,29 @@ struct obj_data *unequip_char(struct char_data *ch, int pos)
 }
 
 
-int get_number(char **name) {
+int get_number(char *name) {
   
-  int i;
   char *ppos;
-  char number[MAX_INPUT_LENGTH];
+  char *cp;
+  int out;
   
-  number[0] = 0;
+  if ((ppos = (char *)index(name, '.')) && ppos[1]) {
 
-  if ((ppos = (char *)index(*name, '.')) && ppos[1]) {
-    *ppos++ = '\0';
-    strcpy(number,*name);
-    strcpy(*name, ppos);
+    *ppos = '\0';
     
-    for(i=0; *(number+i); i++)
-      if (!isdigit(*(number+i)))
+    for(cp = name; cp < ppos; cp++) {
+      if (!isdigit(*cp)) {
+	*ppos = '.';
 	return(0);
-    
-    return(atoi(number));
+      }
+    }
+
+    out = atoi(name);
+
+    /* copy everything after the period, including null termination */
+    memmove(name, ppos+1, strlen(ppos+1) + 1);
+
+    return(out);
   }
   
   return(1);
@@ -988,7 +993,7 @@ struct obj_data *get_obj_in_list(char *name, struct obj_data *list)
   tmp = tmpname;
   
   
-  if (!(number = get_number(&tmp)))
+  if (!(number = get_number(tmp)))
     return(0);
   
   for (i = list, j = 1; i && (j <= number); i = i->next_content)
@@ -1029,7 +1034,7 @@ struct obj_data *get_obj(char *name)
   
   strcpy(tmpname,name);
   tmp = tmpname;
-  if(!(number = get_number(&tmp)))
+  if(!(number = get_number(tmp)))
     return(0);
   
   for (i = object_list, j = 1; i && (j <= number); i = i->next)
@@ -1072,7 +1077,7 @@ struct char_data *get_char_room(char *name, int room)
   
   strcpy(tmpname,name);
   tmp = tmpname;
-  if(!(number = get_number(&tmp)))
+  if(!(number = get_number(tmp)))
     return(0);
   
   for (i = real_roomp(room)->people, j = 1; i && (j <= number); i = i->next_in_room)
@@ -1099,7 +1104,7 @@ struct char_data *get_char(char *name)
   
   strcpy(tmpname,name);
   tmp = tmpname;
-  if(!(number = get_number(&tmp)))
+  if(!(number = get_number(tmp)))
     return(0);
   
   for (i = character_list, j = 1; i && (j <= number); i = i->next)
@@ -1624,7 +1629,7 @@ struct char_data *get_char_room_vis(struct char_data *ch, char *name)
   
   strcpy(tmpname,name);
   tmp = tmpname;
-  if(!(number = get_number(&tmp)))
+  if(!(number = get_number(tmp)))
     return(0);
   
   for (i = real_roomp(ch->in_room)->people, j = 1; 
@@ -1653,7 +1658,7 @@ struct char_data *get_char_vis_world(struct char_data *ch, char *name,
   
   strcpy(tmpname,name);
   tmp = tmpname;
-  if(!(number = get_number(&tmp)))
+  if(!(number = get_number(tmp)))
     return(0);
   
   j = count ? *count : 1;
@@ -1694,7 +1699,7 @@ struct obj_data *get_obj_in_list_vis(struct char_data *ch, char *name,
   
   strcpy(tmpname,name);
   tmp = tmpname;
-  if(!(number = get_number(&tmp)))
+  if(!(number = get_number(tmp)))
     return(0);
   
   for (i = list, j = 1; i && (j <= number); i = i->next_content)
@@ -1719,7 +1724,7 @@ struct obj_data *get_obj_vis_world(struct char_data *ch, char *name,
   
   strcpy(tmpname,name);
   tmp = tmpname;
-  if(!(number = get_number(&tmp)))
+  if(!(number = get_number(tmp)))
     return(0);
   
   j = count ? *count : 1;
@@ -1761,7 +1766,7 @@ struct obj_data *get_obj_vis_accessible(struct char_data *ch, char *name)
   
   strcpy(tmpname,name);
   tmp = tmpname;
-  if(!(number = get_number(&tmp)))
+  if(!(number = get_number(tmp)))
     return(0);
   
   /* scan items carried */

--- a/src/handler.h
+++ b/src/handler.h
@@ -16,5 +16,7 @@
 #define FIND_OBJ_WORLD    16
 #define FIND_OBJ_EQUIP    32
 
+extern int get_number(char *name);
+
 #endif
 

--- a/src/protos.h
+++ b/src/protos.h
@@ -546,7 +546,6 @@ int apply_ac(struct char_data *ch, int eq_pos);
 void equip_char(struct char_data *ch, struct obj_data *obj, int pos);
 int GiveMinStrToWield(struct obj_data *obj, struct char_data *ch);
 struct obj_data *unequip_char(struct char_data *ch, int pos);
-int get_number(char **name);
 struct obj_data *get_obj_in_list(char *name, struct obj_data *list);
 struct obj_data *get_obj_in_list_num(int num, struct obj_data *list);
 struct obj_data *get_obj(char *name);

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -4965,7 +4965,7 @@ int nodrop(struct char_data *ch, int cmd, char *arg,
   else {
     strcpy(buf,obj_name);
     name = buf;
-    if(!(num = get_number(&name))) return(FALSE);
+    if(!(num = get_number(name))) return(FALSE);
   }
 
   /* Look in the room first, in get case */

--- a/src/test.handler.c
+++ b/src/test.handler.c
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <criterion/criterion.h>
+#include "config.h"
+#include "handler.h"
+
+Test(handler, get_number_for_unnumbered_item) {
+  char buf[256];
+  int result;
+  sprintf(buf,"hammer");
+  result = get_number(buf);
+  cr_assert_eq(result, 1);
+  cr_assert_str_eq(buf, "hammer");
+}
+
+Test(handler, get_number_for_numbered_item) {
+  char buf[256];
+  int result;
+  sprintf(buf,"2.hammer");
+  result = get_number(buf);
+  cr_assert_eq(result, 2);
+  cr_assert_str_eq(buf, "hammer");
+}


### PR DESCRIPTION
This was crashing on trying to parse a numbered item like
"2.hammer". The issue was a `strcpy` where the source and
destination strings overlapped, for which "behavior is
undefined" (so I guess an `abort` is a fine thing for a
library to do). This is rewritten to use `memmove` instead.

In addition, since `get_number` never actually modifies the
`char *` that gets passed in as a parameter, there's no need
for the extra level of indirection, and we can simplify its
prototype.

This fixes #32.
