### PR TITLE
Cmd cleanup

### DIFF
--- a/src/act.move.c
+++ b/src/act.move.c
@@ -471,14 +471,14 @@ void do_move(struct char_data *ch, char *UNUSED(argument), int cmd) {
     dir = MOVE_DIR_INVALID;
     break;
   }
-  return move_dir(ch, dir);
+  return move_to_dir(ch, dir);
 }
 
-void move_dir(struct char_data *ch, int dir) {
+void move_to_dir(struct char_data *ch, int dir) {
 
   if (RIDDEN(ch)) {
     if (ride_check(RIDDEN(ch), 0)) {
-      move_dir(RIDDEN(ch), dir);
+      move_to_dir(RIDDEN(ch), dir);
       return;
     }
     else {
@@ -1201,7 +1201,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     for (door = MOVE_DIR_FIRST; door <= MOVE_DIR_LAST; door++)
       if (exit_ok(exitp = EXIT(ch, door), NULL) && exitp->keyword &&
           0 == str_cmp(exitp->keyword, buf)) {
-        move_dir(ch, door);
+        move_to_dir(ch, door);
         return;
       }
     SPRINTF(tmp, "There is no %s here.\n\r", buf);
@@ -1216,7 +1216,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       if (exit_ok(exitp = EXIT(ch, door), &rp) &&
           !IS_SET(exitp->exit_info, EX_CLOSED) &&
           IS_SET(rp->room_flags, INDOORS)) {
-        move_dir(ch, door);
+        move_to_dir(ch, door);
         return;
       }
     send_to_char("You can't seem to find anything to enter.\n\r", ch);
@@ -1235,7 +1235,7 @@ void do_leave(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
       if (exit_ok(exitp = EXIT(ch, door), &rp) &&
           !IS_SET(exitp->exit_info, EX_CLOSED) &&
           !IS_SET(rp->room_flags, INDOORS)) {
-        move_dir(ch, door);
+        move_to_dir(ch, door);
         return;
       }
     send_to_char("I see no obvious exits to the outside.\n\r", ch);

--- a/src/act.move.c
+++ b/src/act.move.c
@@ -1198,7 +1198,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   one_argument(argument, buf);
 
   if (*buf) {                   /* an argument was supplied, search for door keyword */
-    for (door = 0; door <= 5; door++)
+    for (door = MOVE_DIR_FIRST; door <= MOVE_DIR_LAST; door++)
       if (exit_ok(exitp = EXIT(ch, door), NULL) && exitp->keyword &&
           0 == str_cmp(exitp->keyword, buf)) {
         move_dir(ch, door);
@@ -1212,7 +1212,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   }
   else {
     /* try to locate an entrance */
-    for (door = 0; door <= 5; door++)
+    for (door = MOVE_DIR_FIRST; door <= MOVE_DIR_LAST; door++)
       if (exit_ok(exitp = EXIT(ch, door), &rp) &&
           !IS_SET(exitp->exit_info, EX_CLOSED) &&
           IS_SET(rp->room_flags, INDOORS)) {
@@ -1231,7 +1231,7 @@ void do_leave(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
   if (!IS_SET(RM_FLAGS(ch->in_room), INDOORS))
     send_to_char("You are outside.. where do you want to go?\n\r", ch);
   else {
-    for (door = 0; door <= 5; door++)
+    for (door = MOVE_DIR_FIRST; door <= MOVE_DIR_LAST; door++)
       if (exit_ok(exitp = EXIT(ch, door), &rp) &&
           !IS_SET(exitp->exit_info, EX_CLOSED) &&
           !IS_SET(rp->room_flags, INDOORS)) {

--- a/src/act.move.c
+++ b/src/act.move.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "act.move.h"
 
 /*   external vars  */
 #if HASH
@@ -445,10 +446,39 @@ void display_group_move(struct char_data *ch, int dir, int was_in, int total) {
 
 
 void do_move(struct char_data *ch, char *argument, int cmd) {
+  int dir;
+  /* This hardcoded crap will go away soon. */
+  switch (cmd) {
+  case 1:
+    dir = MOVE_DIR_NORTH;
+    break;
+  case 2:
+    dir = MOVE_DIR_EAST;
+    break;
+  case 3:
+    dir = MOVE_DIR_SOUTH;
+    break;
+  case 4:
+    dir = MOVE_DIR_WEST;
+    break;
+  case 5:
+    dir = MOVE_DIR_UP;
+    break;
+  case 6:
+    dir = MOVE_DIR_DOWN;
+    break;
+  default:
+    dir = MOVE_DIR_INVALID;
+    break;
+  }
+  return move_dir(ch, argument, dir);
+}
+
+void move_dir(struct char_data *ch, char *argument, int dir) {
 
   if (RIDDEN(ch)) {
     if (ride_check(RIDDEN(ch), 0)) {
-      do_move(RIDDEN(ch), argument, cmd);
+      move_dir(RIDDEN(ch), argument, dir);
       return;
     }
     else {
@@ -456,8 +486,6 @@ void do_move(struct char_data *ch, char *argument, int cmd) {
       dismount(RIDDEN(ch), ch, POSITION_SITTING);
     }
   }
-
-  cmd -= 1;
 
   /*
    ** the move is valid, check for follower/master conflicts.
@@ -477,14 +505,14 @@ void do_move(struct char_data *ch, char *argument, int cmd) {
 
 
   if (!ch->followers && !ch->master) {
-    move_one(ch, cmd);
+    move_one(ch, dir);
   }
   else {
     if (!ch->followers) {
-      move_one(ch, cmd);
+      move_one(ch, dir);
     }
     else {
-      move_group(ch, cmd);
+      move_group(ch, dir);
     }
   }
 }
@@ -1173,7 +1201,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     for (door = 0; door <= 5; door++)
       if (exit_ok(exitp = EXIT(ch, door), NULL) && exitp->keyword &&
           0 == str_cmp(exitp->keyword, buf)) {
-        do_move(ch, "", ++door);
+        move_dir(ch, "", door);
         return;
       }
     SPRINTF(tmp, "There is no %s here.\n\r", buf);
@@ -1188,7 +1216,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       if (exit_ok(exitp = EXIT(ch, door), &rp) &&
           !IS_SET(exitp->exit_info, EX_CLOSED) &&
           IS_SET(rp->room_flags, INDOORS)) {
-        do_move(ch, "", ++door);
+        move_dir(ch, "", door);
         return;
       }
     send_to_char("You can't seem to find anything to enter.\n\r", ch);
@@ -1207,7 +1235,7 @@ void do_leave(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
       if (exit_ok(exitp = EXIT(ch, door), &rp) &&
           !IS_SET(exitp->exit_info, EX_CLOSED) &&
           !IS_SET(rp->room_flags, INDOORS)) {
-        do_move(ch, "", ++door);
+        move_dir(ch, "", door);
         return;
       }
     send_to_char("I see no obvious exits to the outside.\n\r", ch);

--- a/src/act.move.c
+++ b/src/act.move.c
@@ -445,7 +445,7 @@ void display_group_move(struct char_data *ch, int dir, int was_in, int total) {
 }
 
 
-void do_move(struct char_data *ch, char *argument, int cmd) {
+void do_move(struct char_data *ch, char *UNUSED(argument), int cmd) {
   int dir;
   /* This hardcoded crap will go away soon. */
   switch (cmd) {
@@ -471,14 +471,14 @@ void do_move(struct char_data *ch, char *argument, int cmd) {
     dir = MOVE_DIR_INVALID;
     break;
   }
-  return move_dir(ch, argument, dir);
+  return move_dir(ch, dir);
 }
 
-void move_dir(struct char_data *ch, char *argument, int dir) {
+void move_dir(struct char_data *ch, int dir) {
 
   if (RIDDEN(ch)) {
     if (ride_check(RIDDEN(ch), 0)) {
-      move_dir(RIDDEN(ch), argument, dir);
+      move_dir(RIDDEN(ch), dir);
       return;
     }
     else {
@@ -1201,7 +1201,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     for (door = 0; door <= 5; door++)
       if (exit_ok(exitp = EXIT(ch, door), NULL) && exitp->keyword &&
           0 == str_cmp(exitp->keyword, buf)) {
-        move_dir(ch, "", door);
+        move_dir(ch, door);
         return;
       }
     SPRINTF(tmp, "There is no %s here.\n\r", buf);
@@ -1216,7 +1216,7 @@ void do_enter(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       if (exit_ok(exitp = EXIT(ch, door), &rp) &&
           !IS_SET(exitp->exit_info, EX_CLOSED) &&
           IS_SET(rp->room_flags, INDOORS)) {
-        move_dir(ch, "", door);
+        move_dir(ch, door);
         return;
       }
     send_to_char("You can't seem to find anything to enter.\n\r", ch);
@@ -1235,7 +1235,7 @@ void do_leave(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
       if (exit_ok(exitp = EXIT(ch, door), &rp) &&
           !IS_SET(exitp->exit_info, EX_CLOSED) &&
           !IS_SET(rp->room_flags, INDOORS)) {
-        move_dir(ch, "", door);
+        move_dir(ch, door);
         return;
       }
     send_to_char("I see no obvious exits to the outside.\n\r", ch);

--- a/src/act.move.h
+++ b/src/act.move.h
@@ -1,0 +1,15 @@
+#ifndef _ACT_MOVE_H
+#define _ACT_MOVE_H
+
+#define MOVE_DIR_NORTH 0
+#define MOVE_DIR_EAST 1
+#define MOVE_DIR_SOUTH 2
+#define MOVE_DIR_WEST 3
+#define MOVE_DIR_UP 4
+#define MOVE_DIR_DOWN 5
+
+#define MOVE_DIR_INVALID -1
+
+void move_dir(struct char_data *ch, char *argument, int dir);
+
+#endif /* _ACT_MOVE_H */

--- a/src/act.move.h
+++ b/src/act.move.h
@@ -8,6 +8,9 @@
 #define MOVE_DIR_UP 4
 #define MOVE_DIR_DOWN 5
 
+#define MOVE_DIR_FIRST 0
+#define MOVE_DIR_LAST 5
+
 #define MOVE_DIR_INVALID -1
 
 void move_dir(struct char_data *ch, int dir);

--- a/src/act.move.h
+++ b/src/act.move.h
@@ -13,6 +13,6 @@
 
 #define MOVE_DIR_INVALID -1
 
-void move_dir(struct char_data *ch, int dir);
+void move_to_dir(struct char_data *ch, int dir);
 
 #endif /* _ACT_MOVE_H */

--- a/src/act.move.h
+++ b/src/act.move.h
@@ -10,6 +10,6 @@
 
 #define MOVE_DIR_INVALID -1
 
-void move_dir(struct char_data *ch, char *argument, int dir);
+void move_dir(struct char_data *ch, int dir);
 
 #endif /* _ACT_MOVE_H */

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -1157,7 +1157,11 @@ void do_assist(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 
 
 
-void do_kick(struct char_data *ch, char *argument, int cmd) {
+void do_kick(struct char_data *ch, char *argument, int UNUSED(cmd)) {
+  kick_action(ch, argument, 0);
+}
+
+void kick_action(struct char_data *ch, char *argument, int npc_ok) {
   struct char_data *victim;
   char name[80];
   int dam;
@@ -1175,7 +1179,7 @@ void do_kick(struct char_data *ch, char *argument, int cmd) {
   }
 
 
-  if (!IS_PC(ch) && cmd)
+  if (!IS_PC(ch) && !npc_ok)
     return;
 
   only_argument(argument, name);

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -1013,7 +1013,11 @@ void bash_action(struct char_data *ch, char *argument, int npc_ok) {
 
 
 
-void do_rescue(struct char_data *ch, char *argument, int cmd) {
+void do_rescue(struct char_data *ch, char *argument, int UNUSED(cmd)) {
+  rescue_action(ch, argument, 0);
+}
+
+void rescue_action(struct char_data *ch, char *argument, int npc_ok) {
   struct char_data *victim, *tmp_ch;
   int percent;
   char victim_name[240];
@@ -1024,7 +1028,7 @@ void do_rescue(struct char_data *ch, char *argument, int cmd) {
     return;
   }
 
-  if (!IS_PC(ch) && cmd)
+  if (!IS_PC(ch) && !npc_ok)
     return;
 
   if (check_peaceful(ch, "No one should need rescuing here.\n\r"))

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "act.off.h"
 
 /* extern variables */
 
@@ -903,7 +904,11 @@ void do_flee(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 }
 
 
-void do_bash(struct char_data *ch, char *argument, int cmd) {
+void do_bash(struct char_data *ch, char *argument, int UNUSED(cmd)) {
+  bash_action(ch, argument, 0);
+}
+
+void bash_action(struct char_data *ch, char *argument, int npc_ok) {
   struct char_data *victim;
   char name[256];
   byte percent;
@@ -912,7 +917,7 @@ void do_bash(struct char_data *ch, char *argument, int cmd) {
   if (!ch->skills)
     return;
 
-  if (!IS_PC(ch) && cmd)
+  if (!IS_PC(ch) && !npc_ok)
     return;
 
   if (check_peaceful(ch, "You feel too peaceful to contemplate violence.\n\r"))

--- a/src/act.off.h
+++ b/src/act.off.h
@@ -1,0 +1,6 @@
+#ifndef _ACT_OFF_H
+#define _ACT_OFF_H
+
+void bash_action(struct char_data *ch, char *argument, int npc_ok);
+
+#endif /* ifdef _ACT_OFF_H */

--- a/src/act.off.h
+++ b/src/act.off.h
@@ -2,5 +2,6 @@
 #define _ACT_OFF_H
 
 void bash_action(struct char_data *ch, char *argument, int npc_ok);
+void kick_action(struct char_data *ch, char *argument, int npc_ok);
 
 #endif /* ifdef _ACT_OFF_H */

--- a/src/act.off.h
+++ b/src/act.off.h
@@ -3,5 +3,6 @@
 
 void bash_action(struct char_data *ch, char *argument, int npc_ok);
 void kick_action(struct char_data *ch, char *argument, int npc_ok);
+void rescue_action(struct char_data *ch, char *argument, int npc_ok);
 
 #endif /* ifdef _ACT_OFF_H */

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -2868,15 +2868,12 @@ void do_reroll(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
 }
 
 
-void do_restore(struct char_data *ch, char *argument, int cmd) {
+void do_restore(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   struct char_data *victim;
   char buf[100];
   int i;
 
   void update_pos(struct char_data *victim);
-
-  if (cmd == 0)
-    return;
 
   only_argument(argument, buf);
   if (!*buf)

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -2014,7 +2014,11 @@ void do_switch(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   }
 }
 
-void do_return(struct char_data *ch, char *UNUSED(argument), int cmd) {
+void do_return(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
+  return_action(ch, 1);
+}
+
+void return_action(struct char_data *ch, int call_as_self) {
   struct char_data *mob, *per;
 
   void do_snoop(struct char_data *ch, char *argument, int cmd);
@@ -2043,7 +2047,7 @@ void do_return(struct char_data *ch, char *UNUSED(argument), int cmd) {
                GET_NAME(ch->desc->snoop.snoop_by), 0);
     }
 
-    if (IS_SET(ch->specials.act, ACT_POLYSELF) && cmd) {
+    if (IS_SET(ch->specials.act, ACT_POLYSELF) && call_as_self) {
       mob = ch;
       per = ch->desc->original;
 
@@ -2063,7 +2067,7 @@ void do_return(struct char_data *ch, char *UNUSED(argument), int cmd) {
     ch->desc = 0;
 
 
-    if (IS_SET(ch->specials.act, ACT_POLYSELF) && cmd) {
+    if (IS_SET(ch->specials.act, ACT_POLYSELF) && call_as_self) {
       extract_char(mob);
       WAIT_STATE(ch, PULSE_VIOLENCE);
     }

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -17,6 +17,7 @@
 
 
 #include "protos.h"
+#include "act.wizard.h"
 
 /*   external vars  */
 
@@ -2070,12 +2071,16 @@ void do_return(struct char_data *ch, char *UNUSED(argument), int cmd) {
 }
 
 
-void do_force(struct char_data *ch, char *argument, int cmd) {
+void do_force(struct char_data *ch, char *argument, int UNUSED(cmd)) {
+  force_action(ch, argument, 0);
+}
+
+void force_action(struct char_data *ch, char *argument, int npc_ok) {
   struct descriptor_data *i;
   struct char_data *vict;
   char name[100], to_force[100], buf[100];
 
-  if (IS_NPC(ch) && (cmd != 0))
+  if (IS_NPC(ch) && !npc_ok)
     return;
 
   half_chop(argument, name, to_force);

--- a/src/act.wizard.h
+++ b/src/act.wizard.h
@@ -1,0 +1,6 @@
+#ifndef _ACT_WIZARD_H
+#define _ACT_WIZARD_H
+
+void force_action(struct char_data *ch, char *argument, int npc_ok);
+
+#endif /* _ACT_WIZARD_H */

--- a/src/act.wizard.h
+++ b/src/act.wizard.h
@@ -2,5 +2,6 @@
 #define _ACT_WIZARD_H
 
 void force_action(struct char_data *ch, char *argument, int npc_ok);
+void return_action(struct char_data *ch, int call_as_self);
 
 #endif /* _ACT_WIZARD_H */

--- a/src/handler.c
+++ b/src/handler.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 
 #include "protos.h"
+#include "act.wizard.h"
 
 #if HASH
 extern struct hash_header room_db;
@@ -1425,7 +1426,7 @@ void extract_char_smarter(struct char_data *ch, int save_room) {
   if (!IS_NPC(ch) && !ch->desc) {
     for (t_desc = descriptor_list; t_desc; t_desc = t_desc->next)
       if (t_desc->original == ch)
-        do_return(t_desc->character, "", 0);
+        return_action(t_desc->character, 0);
   }
 
   if (ch->in_room == NOWHERE) {
@@ -1574,7 +1575,7 @@ void extract_char_smarter(struct char_data *ch, int save_room) {
 
   if (ch->desc) {
     if (ch->desc->original)
-      do_return(ch, "", 0);
+      return_action(ch, 0);
     if (!strcmp(GET_NAME(ch), "Odin's heroic minion")) {
       free(GET_NAME(ch));
       GET_NAME(ch) = strdup("111111");

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -927,7 +927,7 @@ void spell_creeping_death(byte UNUSED(level), struct char_data *ch,
 
   /* move the creeping death in the proper direction */
 
-  move_dir(cd, dir);
+  move_to_dir(cd, dir);
 
   GET_POS(ch) = POSITION_STUNNED;
 

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 
 #include "protos.h"
+#include "act.move.h"
 
 /* Extern structures */
 extern struct room_data *world;
@@ -926,7 +927,7 @@ void spell_creeping_death(byte UNUSED(level), struct char_data *ch,
 
   /* move the creeping death in the proper direction */
 
-  do_move(cd, "\0", dir);
+  move_dir(cd, "\0", dir);
 
   GET_POS(ch) = POSITION_STUNNED;
 

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -927,7 +927,7 @@ void spell_creeping_death(byte UNUSED(level), struct char_data *ch,
 
   /* move the creeping death in the proper direction */
 
-  move_dir(cd, "\0", dir);
+  move_dir(cd, dir);
 
   GET_POS(ch) = POSITION_STUNNED;
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -27,7 +27,7 @@ byte HashTable[256];
 
 
 /* Adds a command to the Command List radix. */
-void add_command(char *name, void (*func), int number, int min_pos,
+void add_command(char *name, cmd_handler func, int number, int min_pos,
                  int min_lev) {
   NODE *n;
   int len, radix;

--- a/src/parser.h
+++ b/src/parser.h
@@ -13,10 +13,11 @@
 
 
 typedef struct command_node NODE;
+typedef void (*cmd_handler) (struct char_data * ch, char *arg, int cmd);
 
 struct command_node {
   char *name;
-  void (*func) (struct char_data * ch, char *arg, int cmd);
+  cmd_handler func;
   int number;
   byte min_pos;
   byte min_level;

--- a/src/parser.h
+++ b/src/parser.h
@@ -32,4 +32,7 @@ struct radix_list {
   byte max_len;
 };
 
+void add_command(char *name, cmd_handler func, int number, int min_pos,
+                 int min_lev);
+
 #endif

--- a/src/protos.h
+++ b/src/protos.h
@@ -2102,8 +2102,6 @@ void add_node_tail(NODE * n, int length, int radix);
 NODE *search_for_node_by_name(NODE * head, char *name, int length);
 void init_radix();
 NODE *find_valid_command(char *name);
-void add_command(char *name, void (*func), int number, int min_pos,
-                 int min_lev);
 
 /* from intrinsics.c */
 void do_changeform(struct char_data *ch, char *argument, int cmd);

--- a/src/skills.c
+++ b/src/skills.c
@@ -11,6 +11,7 @@
 
 #include "protos.h"
 #include "skills.h"
+#include "act.move.h"
 
 extern char *dirs[];
 extern struct char_data *character_list;
@@ -683,7 +684,7 @@ int go_direction(struct char_data *ch, int dir) {
     return 0;
 
   if (!IS_SET(EXIT(ch, dir)->exit_info, EX_CLOSED)) {
-    do_move(ch, "", dir + 1);
+    move_dir(ch, "", dir);
   }
   else if (is_humanoid(ch) && !IS_SET(EXIT(ch, dir)->exit_info, EX_LOCKED)) {
     open_door(ch, dir);

--- a/src/skills.c
+++ b/src/skills.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "skills.h"
 
 extern char *dirs[];
 extern struct char_data *character_list;
@@ -189,7 +190,11 @@ void do_inset(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 **  Disarm:
 */
 
-void do_disarm(struct char_data *ch, char *argument, int cmd) {
+void do_disarm(struct char_data *ch, char *argument, int UNUSED(cmd)) {
+  disarm_action(ch, argument, 0);
+}
+
+void disarm_action(struct char_data *ch, char *argument, int npc_ok) {
   char name[30];
   int percent;
   struct char_data *victim;
@@ -201,7 +206,7 @@ void do_disarm(struct char_data *ch, char *argument, int cmd) {
   if (check_peaceful(ch, "You feel too peaceful to contemplate violence.\n\r"))
     return;
 
-  if (!IS_PC(ch) && cmd)
+  if (!IS_PC(ch) && !npc_ok)
     return;
 
   /*

--- a/src/skills.c
+++ b/src/skills.c
@@ -684,7 +684,7 @@ int go_direction(struct char_data *ch, int dir) {
     return 0;
 
   if (!IS_SET(EXIT(ch, dir)->exit_info, EX_CLOSED)) {
-    move_dir(ch, "", dir);
+    move_dir(ch, dir);
   }
   else if (is_humanoid(ch) && !IS_SET(EXIT(ch, dir)->exit_info, EX_LOCKED)) {
     open_door(ch, dir);

--- a/src/skills.c
+++ b/src/skills.c
@@ -684,7 +684,7 @@ int go_direction(struct char_data *ch, int dir) {
     return 0;
 
   if (!IS_SET(EXIT(ch, dir)->exit_info, EX_CLOSED)) {
-    move_dir(ch, dir);
+    move_to_dir(ch, dir);
   }
   else if (is_humanoid(ch) && !IS_SET(EXIT(ch, dir)->exit_info, EX_LOCKED)) {
     open_door(ch, dir);

--- a/src/skills.h
+++ b/src/skills.h
@@ -1,0 +1,6 @@
+#ifndef _SKILLS_H
+#define _SKILLS_H
+
+void disarm_action(struct char_data *ch, char *argument, int npc_ok);
+
+#endif /* _SKILLS_H */

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -14,6 +14,7 @@
 #include "protos.h"
 #include "db.h"
 #include "act.wizard.h"
+#include "act.move.h"
 
 #define INQ_SHOUT 1
 #define INQ_LOOSE 0
@@ -498,7 +499,7 @@ int mayor(struct char_data *ch, int cmd, char *arg, struct char_data *mob,
   case '1':
   case '2':
   case '3':
-    do_move(ch, "", path[index] - '0' + 1);
+    move_dir(ch, "", path[index] - '0');
     break;
 
   case 'W':
@@ -1265,7 +1266,7 @@ void exec_social(struct char_data *npc, char *cmd, int next_line,
     break;
 
   case 'm':
-    do_move(npc, "", *(cmd + 1) - '0' + 1);
+    move_dir(npc, "", *(cmd + 1) - '0');
     break;
 
   case 'w':

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -499,7 +499,7 @@ int mayor(struct char_data *ch, int cmd, char *arg, struct char_data *mob,
   case '1':
   case '2':
   case '3':
-    move_dir(ch, "", path[index] - '0');
+    move_dir(ch, path[index] - '0');
     break;
 
   case 'W':
@@ -1266,7 +1266,7 @@ void exec_social(struct char_data *npc, char *cmd, int next_line,
     break;
 
   case 'm':
-    move_dir(npc, "", *(cmd + 1) - '0');
+    move_dir(npc, *(cmd + 1) - '0');
     break;
 
   case 'w':

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -2058,7 +2058,6 @@ int puff(struct char_data *ch, int cmd, char *UNUSED(arg),
           force_action(ch, buf, 1);
           SPRINTF(buf, "%s mosh", GET_NAME(i));
           force_action(ch, buf, 1);
-          do_restore(ch, GET_NAME(i), 0);
           return (TRUE);
         }
       }

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -13,6 +13,7 @@
 
 #include "protos.h"
 #include "db.h"
+#include "act.wizard.h"
 
 #define INQ_SHOUT 1
 #define INQ_LOOSE 0
@@ -2054,9 +2055,9 @@ int puff(struct char_data *ch, int cmd, char *UNUSED(arg),
       if (!IS_NPC(i)) {
         if (number(0, 30) == 0) {
           SPRINTF(buf, "%s shout I love to MOSH!", GET_NAME(i));
-          do_force(ch, buf, 0);
+          force_action(ch, buf, 1);
           SPRINTF(buf, "%s mosh", GET_NAME(i));
-          do_force(ch, buf, 0);
+          force_action(ch, buf, 1);
           do_restore(ch, GET_NAME(i), 0);
           return (TRUE);
         }
@@ -2202,7 +2203,7 @@ int puff(struct char_data *ch, int cmd, char *UNUSED(arg),
         if (number(0, 20) == 0) {
           if (i->in_room != NOWHERE) {
             SPRINTF(buf, "%s save", GET_NAME(i));
-            do_force(ch, buf, 0);
+            force_action(ch, buf, 1);
             return (TRUE);
           }
         }

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -499,7 +499,7 @@ int mayor(struct char_data *ch, int cmd, char *arg, struct char_data *mob,
   case '1':
   case '2':
   case '3':
-    move_dir(ch, path[index] - '0');
+    move_to_dir(ch, path[index] - '0');
     break;
 
   case 'W':
@@ -1266,7 +1266,7 @@ void exec_social(struct char_data *npc, char *cmd, int next_line,
     break;
 
   case 'm':
-    move_dir(npc, *(cmd + 1) - '0');
+    move_to_dir(npc, *(cmd + 1) - '0');
     break;
 
   case 'w':

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -2121,7 +2121,7 @@ int creeping_death(struct char_data *ch, int cmd, char *UNUSED(arg),
       return (FALSE);
     }
     else {
-      move_dir(ch, "\0", ch->generic);
+      move_dir(ch, ch->generic);
       return (FALSE);
     }
   }

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -12,6 +12,7 @@
 
 #include "protos.h"
 #include "act.off.h"
+#include "act.wizard.h"
 
 /*   external vars  */
 
@@ -1673,7 +1674,7 @@ int samah(struct char_data *ch, int cmd, char *arg,
             act("$n traces a small rune in the air", FALSE, ch, 0, 0, TO_ROOM);
             act("$n has forced you to return to your original form!", FALSE,
                 ch, 0, t, TO_VICT);
-            do_return(t, "", 1);
+            return_action(t, 1);
             return (TRUE);
           }
         }
@@ -3071,7 +3072,7 @@ int druid_challenge_room(struct char_data *ch, int cmd, char *UNUSED(arg),
     send_to_char("You lose.\n\r", ch);
     if (IS_PC(ch)) {
       if (IS_NPC(ch)) {
-        do_return(ch, "", 0);
+        return_action(ch, 0);
       }
       GET_EXP(ch) = MIN(titles[DRUID_LEVEL_IND]
                         [(int)GET_LEVEL(ch, DRUID_LEVEL_IND)].exp,
@@ -3095,7 +3096,7 @@ int druid_challenge_room(struct char_data *ch, int cmd, char *UNUSED(arg),
         for (i = me->people; i; i = i->next_in_room)
           if (IS_PC(i)) {
             if (IS_NPC(i)) {
-              do_return(i, "", 0);
+              return_action(i, 0);
             }
             GET_EXP(i) = MAX(titles[DRUID_LEVEL_IND]
                              [GET_LEVEL(i, DRUID_LEVEL_IND) + 1].exp + 1,
@@ -3162,7 +3163,7 @@ int monk_challenge_room(struct char_data *ch, int cmd, char *UNUSED(arg),
     send_to_char("You lose.\n\r", ch);
     if (IS_PC(ch)) {
       if (IS_NPC(ch)) {
-        do_return(ch, "", 0);
+        return_action(ch, 0);
       }
       GET_EXP(ch) = MIN(titles[MONK_LEVEL_IND]
                         [(int)GET_LEVEL(ch, MONK_LEVEL_IND)].exp, GET_EXP(ch));
@@ -3192,7 +3193,7 @@ int monk_challenge_room(struct char_data *ch, int cmd, char *UNUSED(arg),
         for (i = me->people; i; i = i->next_in_room)
           if (IS_PC(i)) {
             if (IS_NPC(i)) {
-              do_return(i, "", 0);
+              return_action(i, 0);
             }
             if (IS_IMMORTAL(i))
               return (FALSE);

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -11,6 +11,7 @@
 #include <ctype.h>
 
 #include "protos.h"
+#include "act.off.h"
 
 /*   external vars  */
 
@@ -2396,7 +2397,7 @@ int generic_cityguardHateUndead(struct char_data *ch, int cmd, char *arg,
 
       if (!ch->skills[SKILL_RESCUE].learned)
         ch->skills[SKILL_RESCUE].learned = get_max_level(ch) * 3 + 30;
-      do_rescue(ch, GET_NAME(evil->specials.fighting), 0);
+      rescue_action(ch, GET_NAME(evil->specials.fighting), 1);
     }
   }
 

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -2121,7 +2121,7 @@ int creeping_death(struct char_data *ch, int cmd, char *UNUSED(arg),
       return (FALSE);
     }
     else {
-      move_dir(ch, ch->generic);
+      move_to_dir(ch, ch->generic);
       return (FALSE);
     }
   }

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -13,6 +13,7 @@
 #include "protos.h"
 #include "act.off.h"
 #include "act.wizard.h"
+#include "act.move.h"
 
 /*   external vars  */
 
@@ -2120,7 +2121,7 @@ int creeping_death(struct char_data *ch, int cmd, char *UNUSED(arg),
       return (FALSE);
     }
     else {
-      do_move(ch, "\0", ch->generic);
+      move_dir(ch, "\0", ch->generic);
       return (FALSE);
     }
   }

--- a/src/spells2.c
+++ b/src/spells2.c
@@ -3188,7 +3188,6 @@ void cast_creeping_death(byte level, struct char_data *ch, char *arg,
     p = fname(arg);
     for (i = 0; i < 6; i++) {
       if (strncmp(p, dirs[i], strlen(p)) == 0) {
-        i++;
         break;
       }
       if (i == 6) {

--- a/src/utility.c
+++ b/src/utility.c
@@ -1714,13 +1714,13 @@ void make_nifty_attack(struct char_data *ch) {
     else {
       if (!ch->skills[SKILL_KICK].learned)
         ch->skills[SKILL_KICK].learned = 10 + get_max_level(ch) * 4;
-      do_kick(ch, GET_NAME(ch->specials.fighting), 0);
+      kick_action(ch, GET_NAME(ch->specials.fighting), 1);
     }
   }
   else {
     if (!ch->skills[SKILL_KICK].learned)
       ch->skills[SKILL_KICK].learned = 10 + get_max_level(ch) * 4;
-    do_kick(ch, GET_NAME(ch->specials.fighting), 0);
+    kick_action(ch, GET_NAME(ch->specials.fighting), 1);
   }
 }
 
@@ -1823,7 +1823,7 @@ void monk_move(struct char_data *ch) {
       }
       if (!ch->skills[SKILL_KICK].learned)
         ch->skills[SKILL_KICK].learned = (get_max_level(ch) * 3) / 2 + 25;
-      do_kick(ch, GET_NAME(ch->specials.fighting), 0);
+      kick_action(ch, GET_NAME(ch->specials.fighting), 1);
     }
   }
 }

--- a/src/utility.c
+++ b/src/utility.c
@@ -14,6 +14,7 @@
 
 #include "protos.h"
 #include "utility.h"
+#include "act.off.h"
 
 void log_msg(char *s) {
   log_sev(s, 1);
@@ -1701,7 +1702,7 @@ void make_nifty_attack(struct char_data *ch) {
   if (num <= 2) {
     if (!ch->skills[SKILL_BASH].learned)
       ch->skills[SKILL_BASH].learned = 10 + get_max_level(ch) * 4;
-    do_bash(ch, GET_NAME(ch->specials.fighting), 0);
+    bash_action(ch, GET_NAME(ch->specials.fighting), 1);
   }
   else if (num == 3) {
     if (ch->equipment[WIELD]) {

--- a/src/utility.c
+++ b/src/utility.c
@@ -15,6 +15,7 @@
 #include "protos.h"
 #include "utility.h"
 #include "act.off.h"
+#include "skills.h"
 
 void log_msg(char *s) {
   log_sev(s, 1);
@@ -1708,7 +1709,7 @@ void make_nifty_attack(struct char_data *ch) {
     if (ch->equipment[WIELD]) {
       if (!ch->skills[SKILL_DISARM].learned)
         ch->skills[SKILL_DISARM].learned = 10 + get_max_level(ch) * 4;
-      do_disarm(ch, GET_NAME(ch->specials.fighting), 0);
+      disarm_action(ch, GET_NAME(ch->specials.fighting), 1);
     }
     else {
       if (!ch->skills[SKILL_KICK].learned)
@@ -1817,7 +1818,7 @@ void monk_move(struct char_data *ch) {
       if (ch->specials.fighting->equipment[WIELD]) {
         if (!ch->skills[SKILL_DISARM].learned)
           ch->skills[SKILL_DISARM].learned = (get_max_level(ch) * 3) / 2 + 25;
-        do_disarm(ch, GET_NAME(ch->specials.fighting), 0);
+        disarm_action(ch, GET_NAME(ch->specials.fighting), 1);
         return;
       }
       if (!ch->skills[SKILL_KICK].learned)

--- a/src/utility.c
+++ b/src/utility.c
@@ -1744,7 +1744,7 @@ void fighter_move(struct char_data *ch) {
         if (GET_HIT(friend) < GET_HIT(ch)) {
           if (!ch->skills[SKILL_RESCUE].learned)
             ch->skills[SKILL_RESCUE].learned = get_max_level(ch) * 3 + 30;
-          do_rescue(ch, GET_NAME(friend), 0);
+          rescue_action(ch, GET_NAME(friend), 1);
         }
         else {
           make_nifty_attack(ch);


### PR DESCRIPTION
The goal of this is to eventually remove the hard-coded command numbers from the codebase. These are intermediary steps, primarily:
- Add type-checking for the command functions
- Standardize movement directions (sometimes 1 meant North, sometimes 0 meant North)
- If the `cmd` arg of any of the `do_*` functions had been overloaded to mean something else, separate the code out into two functions to make the extra functionality explicit.
