### PR TITLE
Remove extraneous function prototypes

### DIFF
--- a/src/act.move.c
+++ b/src/act.move.c
@@ -1428,9 +1428,6 @@ void do_follow(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   char name[160];
   struct char_data *leader;
 
-  void stop_follower(struct char_data *ch);
-  void add_follower(struct char_data *ch, struct char_data *leader);
-
   only_argument(argument, name);
 
   if (*name) {

--- a/src/act.move.c
+++ b/src/act.move.c
@@ -137,8 +137,6 @@ int raw_move(struct char_data *ch, int dir) {
   bool has_boat;
   struct room_data *from_here, *to_here;
 
-  int special(struct char_data *ch, int dir, char *arg);
-
   if (special(ch, dir + 1, "")) /* Check for special routines(North is 1) */
     return (FALSE);
 

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -396,8 +396,6 @@ void do_flee(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   int i, attempt, loose =
     0, die, percent, charm, nmbr, f, panic, j, tries, badroom;
   bool found;
-  void gain_exp(struct char_data *ch, int gain);
-  int special(struct char_data *ch, int cmd, char *arg);
   char buf[255];
   char buf2[255];
 

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -175,7 +175,6 @@ void do_title(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 }
 
 void do_quit(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
-  void die(struct char_data *ch);
   char buf[256];
 
   if (IS_NPC(ch) || !ch->desc || IS_AFFECTED(ch, AFF_CHARM))

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -922,8 +922,6 @@ void do_goto(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   struct char_data *target_mob, *pers, *v;
   struct obj_data *target_obj;
 
-  void do_look(struct char_data *ch, char *argument, int cmd);
-
   if (IS_NPC(ch))
     return;
   if ((get_max_level(ch) > 0) && (get_max_level(ch) < LOW_IMMORTAL)) {
@@ -2016,8 +2014,6 @@ void do_switch(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 void do_return(struct char_data *ch, char *UNUSED(argument), int cmd) {
   struct char_data *mob, *per;
 
-  void do_snoop(struct char_data *ch, char *argument, int cmd);
-
   if (get_max_level(ch) < LOW_IMMORTAL)
     if (ch->specials.fighting) {
       send_to_char("You are far too busy fighting to return now!\n\r", ch);
@@ -2730,8 +2726,6 @@ void do_advance(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   char name[100], level[100], class[100];
   int adv, newlevel, lin_class;
 
-  void gain_exp(struct char_data *ch, int gain);
-
   if (IS_NPC(ch))
     return;
 
@@ -2867,8 +2861,6 @@ void do_restore(struct char_data *ch, char *argument, int cmd) {
   struct char_data *victim;
   char buf[100];
   int i;
-
-  void update_pos(struct char_data *victim);
 
   if (cmd == 0)
     return;

--- a/src/comm.c
+++ b/src/comm.c
@@ -1167,8 +1167,6 @@ void coma(int s) {
   };
   int conn;
 
-  int workhours(void);
-  int load(void);
 #ifdef HAVE_SIGPROCMASK
   sigset_t sigmask;
 #endif

--- a/src/comm.c
+++ b/src/comm.c
@@ -212,9 +212,6 @@ void run_the_game(int port) {
   int s;
   PROFILE(extern etext();)
 
-  void signal_setup(void);
-  int load(void);
-
   PROFILE(monstartup((int)2, etext);)
 
     descriptor_list = NULL;
@@ -1041,8 +1038,6 @@ void close_socket(struct descriptor_data *d) {
   struct descriptor_data *tmp;
   char buf[100];
   struct txt_block *txt, *txt2;
-
-  void do_save(struct char_data *ch, char *argument, int cmd);
 
   if (!d)
     return;

--- a/src/db.c
+++ b/src/db.c
@@ -2156,8 +2156,6 @@ int load_char(char *name, struct char_file_u *char_element) {
   FILE *fl;
   int player_i;
 
-  int find_name(char *name);
-
   if ((player_i = find_name(name)) >= 0) {
 
     if (!(fl = fopen(PLAYER_FILE, "r"))) {

--- a/src/handler.c
+++ b/src/handler.c
@@ -1414,11 +1414,6 @@ void extract_char_smarter(struct char_data *ch, int save_room) {
   extern long mob_count;
   extern struct char_data *combat_list;
 
-  void do_save(struct char_data *ch, char *argument, int cmd);
-  void do_return(struct char_data *ch, char *argument, int cmd);
-
-  void die_follower(struct char_data *ch);
-
   if (IS_SET(ch->specials.act, ACT_FIGURINE) && ch->link)
     extract_obj(ch->link);
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -864,10 +864,6 @@ void nanny(struct descriptor_data *d, char *arg) {
   extern int top_of_mobt;
   extern int RacialMax[][6];
 
-  void do_look(struct char_data *ch, char *argument, int cmd);
-  void load_char_objs(struct char_data *ch);
-  int load_char(char *name, struct char_file_u *char_element);
-
   write(d->descriptor, echo_on, 6);
 
   switch (STATE(d)) {

--- a/src/limits.c
+++ b/src/limits.c
@@ -817,9 +817,6 @@ void gain_condition(struct char_data *ch, int condition, int value) {
 
 
 void check_idling(struct char_data *ch) {
-  void do_save(struct char_data *ch, char *argument, int cmd);
-
-
   if (++(ch->specials.timer) == 8) {
     do_save(ch, "", 0);
 

--- a/src/magic.c
+++ b/src/magic.c
@@ -750,8 +750,6 @@ void spell_create_water(byte level, struct char_data *ch,
   int water;
 
   extern struct weather_data weather_info;
-  void name_to_drinkcon(struct obj_data *obj, int type);
-  void name_from_drinkcon(struct obj_data *obj);
 
   assert(ch && obj);
 
@@ -1686,8 +1684,6 @@ void spell_word_of_recall(byte UNUSED(level), struct char_data *UNUSED(ch),
   extern int top_of_world;
   int location;
 
-  void do_look(struct char_data *ch, char *argument, int cmd);
-
   assert(victim);
 
   if (IS_NPC(victim))
@@ -1889,10 +1885,6 @@ void spell_charm_person(byte UNUSED(level), struct char_data *ch,
                         struct obj_data *UNUSED(obj)) {
   struct affected_type af;
 
-  void add_follower(struct char_data *ch, struct char_data *leader);
-  bool circle_follow(struct char_data *ch, struct char_data *victim);
-  void stop_follower(struct char_data *ch);
-
   assert(ch && victim);
 
   if (victim == ch) {
@@ -1986,10 +1978,6 @@ void spell_charm_monster(byte UNUSED(level), struct char_data *ch,
                          struct char_data *victim,
                          struct obj_data *UNUSED(obj)) {
   struct affected_type af;
-
-  void add_follower(struct char_data *ch, struct char_data *leader);
-  bool circle_follow(struct char_data *ch, struct char_data *victim);
-  void stop_follower(struct char_data *ch);
 
   assert(ch && victim);
 

--- a/src/magic.c
+++ b/src/magic.c
@@ -2365,8 +2365,6 @@ void spell_acid_breath(byte level, struct char_data *ch,
   int dam;
   int hpch;
 
-  int apply_ac(struct char_data *ch, int eq_pos);
-
   assert(victim && ch);
   assert((level >= 1) && (level <= ABS_MAX_LVL));
 

--- a/src/magic2.c
+++ b/src/magic2.c
@@ -1497,8 +1497,6 @@ void spell_dispel_magic(byte level, struct char_data *ch,
   int yes = 0;
   int i;
 
-  int check_falling(struct char_data *ch);
-
   assert(ch && (victim || obj));
 
   if (obj) {

--- a/src/magic2.c
+++ b/src/magic2.c
@@ -765,8 +765,6 @@ void spell_poly_self(byte UNUSED(level), struct char_data *ch,
 
   char *buf;
 
-  void do_snoop(struct char_data *ch, char *argument, int cmd);
-
   /*
    *  Check to make sure that there is no snooping going on.
    */

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -1305,10 +1305,6 @@ void spell_charm_veggie(byte UNUSED(level), struct char_data *ch,
                         struct obj_data *UNUSED(obj)) {
   struct affected_type af;
 
-  void add_follower(struct char_data *ch, struct char_data *leader);
-  bool circle_follow(struct char_data *ch, struct char_data *victim);
-  void stop_follower(struct char_data *ch);
-
   assert(ch && victim);
 
   if (victim == ch) {

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -260,9 +260,6 @@ void mobile_activity(struct char_data *ch) {
   int k;
   extern int no_specials;
 
-  void do_move(struct char_data *ch, char *argument, int cmd);
-  void do_get(struct char_data *ch, char *argument, int cmd);
-
   /* Examine call for special procedure */
 
   /* some status checking for errors */

--- a/src/modify.c
+++ b/src/modify.c
@@ -958,8 +958,6 @@ void night_watchman() {
 
   extern int mudshutdown;
 
-  void send_to_all(char *messg);
-
   tc = time(0);
   t_info = localtime(&tc);
 

--- a/src/pcedit.c
+++ b/src/pcedit.c
@@ -167,7 +167,6 @@ void menu2() {
 }
 
 void muck(int orig_ammt, char name[80]) {
-  void menu2();
   register i;
   int l, count, f;
   char temp[10];

--- a/src/pcedit.c
+++ b/src/pcedit.c
@@ -375,8 +375,6 @@ int search_for_name_from_pos(char *arg, int pos)
 
 void access_rent_files(int number, int ITEM, char buf[40]) {
 /*
-  int read_objs(FILE *fl, struct obj_file_u *st);
-
   char buff2[80];
   FILE *fl;
   int i,j,tried,succeed;

--- a/src/reception.c
+++ b/src/reception.c
@@ -188,8 +188,6 @@ void obj_store_to_char(struct char_data *ch, struct obj_file_u *st) {
   struct obj_data *obj;
   int i, j;
 
-  void obj_to_char(struct obj_data *object, struct char_data *ch);
-
   for (i = 0; i < st->number; i++) {
     if (st->objects[i].item_number > -1 &&
         real_object(st->objects[i].item_number) > -1) {

--- a/src/reception.c
+++ b/src/reception.c
@@ -494,8 +494,6 @@ void update_obj_file() {
   long days_passed, secs_lost;
   char buf[200];
 
-  int find_name(char *name);
-
   if (!(char_file = fopen(PLAYER_FILE, "r+"))) {
     perror("Opening player file for reading. (reception.c, update_obj_file)");
     assert(0);

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -458,13 +458,6 @@ int mayor(struct char_data *ch, int cmd, char *arg, struct char_data *mob,
   static int index;
   static bool move = FALSE;
 
-  void do_move(struct char_data *ch, char *argument, int cmd);
-  void do_open(struct char_data *ch, char *argument, int cmd);
-  void do_lock(struct char_data *ch, char *argument, int cmd);
-  void do_unlock(struct char_data *ch, char *argument, int cmd);
-  void do_close(struct char_data *ch, char *argument, int cmd);
-
-
   if (type == EVENT_WINTER) {
     GET_POS(ch) = POSITION_STANDING;
     do_shout(ch, "Aieee!   The rats!  The rats are coming!  Aieeee!", 0);
@@ -1230,12 +1223,6 @@ void exec_social(struct char_data *npc, char *cmd, int next_line,
                  int *cur_line, void **thing) {
   bool ok;
 
-  void do_move(struct char_data *ch, char *argument, int cmd);
-  void do_open(struct char_data *ch, char *argument, int cmd);
-  void do_lock(struct char_data *ch, char *argument, int cmd);
-  void do_unlock(struct char_data *ch, char *argument, int cmd);
-  void do_close(struct char_data *ch, char *argument, int cmd);
-
   if (GET_POS(npc) == POSITION_FIGHTING)
     return;
 
@@ -1354,8 +1341,6 @@ void npc_steal(struct char_data *ch, struct char_data *victim) {
 
 int snake(struct char_data *ch, int cmd, char *UNUSED(arg),
           struct char_data *UNUSED(mob), int UNUSED(type)) {
-  void cast_poison(byte level, struct char_data *ch, char *arg, int type,
-                   struct char_data *tar_ch, struct obj_data *tar_obj);
 
   if (cmd || !AWAKE(ch))
     return (FALSE);
@@ -1624,9 +1609,6 @@ int ghoul(struct char_data *ch, int cmd, char *UNUSED(arg),
           struct char_data *UNUSED(mob), int UNUSED(type)) {
   struct char_data *tar;
 
-  void cast_paralyze(byte level, struct char_data *ch, char *arg, int type,
-                     struct char_data *tar_ch, struct obj_data *tar_obj);
-
   if (cmd || !AWAKE(ch))
     return (FALSE);
 
@@ -1652,9 +1634,6 @@ int carrion_crawler(struct char_data *ch, int cmd, char *UNUSED(arg),
                     struct char_data *UNUSED(mob), int UNUSED(type)) {
   struct char_data *tar;
   int i;
-
-  void cast_paralyze(byte level, struct char_data *ch, char *arg, int type,
-                     struct char_data *tar_ch, struct obj_data *tar_obj);
 
   if (cmd || !AWAKE(ch))
     return (FALSE);
@@ -1715,9 +1694,6 @@ int wizard_guard(struct char_data *ch, int cmd, char *arg,
 
 int vampire(struct char_data *ch, int cmd, char *UNUSED(arg),
             struct char_data *UNUSED(mob), int UNUSED(type)) {
-  void cast_energy_drain(byte level, struct char_data *ch, char *arg, int type,
-                         struct char_data *tar_ch, struct obj_data *tar_obj);
-
   if (cmd || !AWAKE(ch))
     return (FALSE);
 
@@ -1738,9 +1714,6 @@ int vampire(struct char_data *ch, int cmd, char *UNUSED(arg),
 
 int wraith(struct char_data *ch, int cmd, char *UNUSED(arg),
            struct char_data *UNUSED(mob), int UNUSED(type)) {
-  void cast_energy_drain(byte level, struct char_data *ch, char *arg, int type,
-                         struct char_data *tar_ch, struct obj_data *tar_obj);
-
   if (cmd || !AWAKE(ch))
     return (FALSE);
 
@@ -1757,11 +1730,6 @@ int wraith(struct char_data *ch, int cmd, char *UNUSED(arg),
 
 int shadow(struct char_data *ch, int cmd, char *UNUSED(arg),
            struct char_data *UNUSED(mob), int UNUSED(type)) {
-  void cast_chill_touch(byte level, struct char_data *ch, char *arg, int type,
-                        struct char_data *tar_ch, struct obj_data *tar_obj);
-  void cast_weakness(byte level, struct char_data *ch, char *arg, int type,
-                     struct char_data *tar_ch, struct obj_data *tar_obj);
-
   if (cmd || !AWAKE(ch))
     return (FALSE);
 
@@ -1781,9 +1749,6 @@ int shadow(struct char_data *ch, int cmd, char *UNUSED(arg),
 int geyser(struct char_data *ch, int cmd, char *UNUSED(arg),
            struct char_data *UNUSED(mob), int UNUSED(type)) {
 
-  void cast_geyser(byte level, struct char_data *ch, char *arg, int type,
-                   struct char_data *tar_ch, struct obj_data *tar_obj);
-
   if (cmd || !AWAKE(ch))
     return (FALSE);
 
@@ -1799,9 +1764,6 @@ int geyser(struct char_data *ch, int cmd, char *UNUSED(arg),
 int green_slime(struct char_data *ch, int cmd, char *UNUSED(arg),
                 struct char_data *UNUSED(mob), int UNUSED(type)) {
   struct char_data *cons;
-
-  void cast_green_slime(byte level, struct char_data *ch, char *arg, int type,
-                        struct char_data *tar_ch, struct obj_data *tar_obj);
 
   if (cmd || !AWAKE(ch))
     return (FALSE);
@@ -1902,10 +1864,6 @@ int puff(struct char_data *ch, int cmd, char *UNUSED(arg),
          struct char_data *UNUSED(mob), int type) {
   struct char_data *i, *tmp_ch;
   char buf[80];
-
-  void do_say(struct char_data *ch, char *argument, int cmd);
-  void do_emote(struct char_data *ch, char *argument, int cmd);
-  void do_shout(struct char_data *ch, char *argument, int cmd);
 
   if (type == EVENT_DWARVES_STRIKE) {
     do_shout(ch,
@@ -2580,9 +2538,7 @@ int rust_monster(struct char_data *ch, int cmd, char *UNUSED(arg),
 
 int temple_labrynth_liar(struct char_data *ch, int cmd, char *UNUSED(arg),
                          struct char_data *UNUSED(mob), int UNUSED(type)) {
-  void do_say(struct char_data *ch, char *argument, int cmd);
-
-  if (cmd || !AWAKE(ch))
+    if (cmd || !AWAKE(ch))
     return (0);
 
   if (check_soundproof(ch))
@@ -2629,10 +2585,6 @@ int temple_labrynth_sentry(struct char_data *ch, int cmd, char *UNUSED(arg),
                            struct char_data *UNUSED(mob), int UNUSED(type)) {
   struct char_data *tch;
   int counter;
-
-  void cast_fireball(byte level, struct char_data *ch, char *arg, int type,
-                     struct char_data *victim, struct obj_data *tar_obj);
-  void do_say(struct char_data *ch, char *argument, int cmd);
 
   if (cmd || !AWAKE(ch))
     return FALSE;
@@ -3250,10 +3202,6 @@ int fountain(struct char_data *ch, int cmd, char *arg,
   struct char_data *tmp_char;
   char container[20];           /* so we can be flexible */
   struct obj_data *obj;
-
-  void name_to_drinkcon(struct obj_data *obj, int type);
-  void name_from_drinkcon(struct obj_data *obj);
-
 
   if (cmd == 248) {             /* fill */
 

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -2538,7 +2538,7 @@ int rust_monster(struct char_data *ch, int cmd, char *UNUSED(arg),
 
 int temple_labrynth_liar(struct char_data *ch, int cmd, char *UNUSED(arg),
                          struct char_data *UNUSED(mob), int UNUSED(type)) {
-    if (cmd || !AWAKE(ch))
+  if (cmd || !AWAKE(ch))
     return (0);
 
   if (check_soundproof(ch))

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -42,9 +42,6 @@ extern int gSeason;             /* what season is it ? */
 
 int ghost(struct char_data *ch, int cmd, char *UNUSED(arg),
           struct char_data *UNUSED(mob), int UNUSED(type)) {
-  void cast_energy_drain(byte level, struct char_data *ch, char *arg,
-                         int type, struct char_data *tar_ch,
-                         struct obj_data *tar_obj);
 
   if (cmd || !AWAKE(ch))
     return (FALSE);
@@ -108,9 +105,6 @@ int magic__fountain(struct char_data *ch, int cmd, char *arg,
                     struct room_data *UNUSED(rp), int UNUSED(type)) {
 
   char buf[MAX_INPUT_LENGTH];
-
-  void name_to_drinkcon(struct obj_data *obj, int type);
-  void name_from_drinkcon(struct obj_data *obj);
 
   if (cmd == 11) {              /* drink */
 
@@ -3866,10 +3860,6 @@ extern float shop_multiplier;
 
 int dwarven_miners(struct char_data *ch, int UNUSED(cmd), char *UNUSED(arg),
                    struct char_data *UNUSED(mob), int type) {
-  void do_emote(struct char_data *ch, char *arg, int cmd);
-  void do_stand(struct char_data *ch, char *arg, int cmd);
-  void do_sit(struct char_data *ch, char *arg, int cmd);
-
   if (type == PULSE_COMMAND)
     return (FALSE);
 

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -460,10 +460,6 @@ void affect_update(int pulse) {
   extern struct time_info_data time_info;
 
 
-  void update_char_objects(struct char_data *ch);       /* handler.c */
-  void do_save(struct char_data *ch, char *arg, int cmd);       /* act.other.c */
-
-
   for (i = character_list; i; i = next_char) {
     next_char = i->next;
     /*


### PR DESCRIPTION
Pull out a bunch (I probably missed a few) of those prototypes declared within function scopes. Who writes this crap?
