### PR TITLE
Feature/improve logs

### DIFF
--- a/src/Trap.c
+++ b/src/Trap.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 extern struct char_data *character_list;
 struct room_data *real_roomp(int);
@@ -121,8 +122,6 @@ void find_trap_damage(struct char_data *v, struct obj_data *i) {
 
 void trap_damage(struct char_data *v, int damtype, int amnt,
                  struct obj_data *t) {
-  char buf[132];
-
   amnt = skip_immortals(v, amnt);
   if (amnt == -1) {
     return;
@@ -150,9 +149,8 @@ void trap_damage(struct char_data *v, int damtype, int amnt,
   if (GET_POS(v) == POSITION_DEAD) {
     if (!IS_NPC(v)) {
       if (real_roomp(v->in_room)->name)
-        SPRINTF(buf, "%s killed by a trap at %s",
-                GET_NAME(v), real_roomp(v->in_room)->name);
-      log_msg(buf);
+        log_msgf("%s killed by a trap at %s",
+                 GET_NAME(v), real_roomp(v->in_room)->name);
     }
 
     die(v);

--- a/src/act.move.c
+++ b/src/act.move.c
@@ -10,6 +10,7 @@
 
 #include "protos.h"
 #include "act.move.h"
+#include "utility.h"
 
 /*   external vars  */
 #if HASH
@@ -749,8 +750,7 @@ void open_door(struct char_data *ch, int dir)
 
   rp = real_roomp(ch->in_room);
   if (rp == NULL) {
-    SPRINTF(buf, "NULL rp in open_door() for %s.", PERS(ch, ch));
-    log_msg(buf);
+    log_msgf("NULL rp in open_door() for %s.", PERS(ch, ch));
   }
 
   exitp = rp->dir_option[dir];
@@ -795,8 +795,7 @@ void raw_open_door(struct char_data *ch, int dir)
 
   rp = real_roomp(ch->in_room);
   if (rp == NULL) {
-    SPRINTF(buf, "NULL rp in open_door() for %s.", PERS(ch, ch));
-    log_msg(buf);
+    log_msgf("NULL rp in open_door() for %s.", PERS(ch, ch));
   }
 
   exitp = rp->dir_option[dir];
@@ -947,7 +946,6 @@ void raw_unlock_door(struct char_data *ch,
                      struct room_direction_data *exitp, int door) {
   struct room_data *rp;
   struct room_direction_data *back;
-  char buf[128];
 
   REMOVE_BIT(exitp->exit_info, EX_LOCKED);
   /* now for unlocking the other side, too */
@@ -957,9 +955,8 @@ void raw_unlock_door(struct char_data *ch,
     REMOVE_BIT(back->exit_info, EX_LOCKED);
   }
   else {
-    SPRINTF(buf, "Inconsistent door locks in rooms %d->%d",
-            ch->in_room, exitp->to_room);
-    log_msg(buf);
+    log_msgf("Inconsistent door locks in rooms %d->%d",
+             ch->in_room, exitp->to_room);
   }
 }
 
@@ -967,7 +964,6 @@ void raw_lock_door(struct char_data *ch,
                    struct room_direction_data *exitp, int door) {
   struct room_data *rp;
   struct room_direction_data *back;
-  char buf[128];
 
   SET_BIT(exitp->exit_info, EX_LOCKED);
   /* now for locking the other side, too */
@@ -977,9 +973,8 @@ void raw_lock_door(struct char_data *ch,
     SET_BIT(back->exit_info, EX_LOCKED);
   }
   else {
-    SPRINTF(buf, "Inconsistent door locks in rooms %d->%d",
-            ch->in_room, exitp->to_room);
-    log_msg(buf);
+    log_msgf("Inconsistent door locks in rooms %d->%d",
+             ch->in_room, exitp->to_room);
   }
 }
 

--- a/src/act.obj1.c
+++ b/src/act.obj1.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 /* extern variables */
 
@@ -62,10 +63,8 @@ void get(struct char_data *ch, struct obj_data *obj_object,
     send_to_char(buffer, ch);
     GET_GOLD(ch) += obj_object->obj_flags.value[0];
     if (GET_GOLD(ch) > 100000 && obj_object->obj_flags.value[0] > 10000) {
-      char buf[MAX_INPUT_LENGTH];
-      SPRINTF(buf, "%s just got %d coins!",
-              GET_NAME(ch), obj_object->obj_flags.value[0]);
-      log_msg(buf);
+      log_msgf("%s just got %d coins!",
+               GET_NAME(ch), obj_object->obj_flags.value[0]);
     }
     extract_obj(obj_object);
   }
@@ -739,9 +738,8 @@ void do_give(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     GET_GOLD(vict) += amount;
     save_char(ch, AUTO_RENT);
     if ((GET_GOLD(vict) > 500000) && (amount > 100000)) {
-      SPRINTF(buf, "%s gave %d coins to %s", GET_NAME(ch), amount,
-              GET_NAME(vict));
-      log_msg(buf);
+      log_msgf("%s gave %d coins to %s", GET_NAME(ch), amount,
+               GET_NAME(vict));
     }
 
     return;

--- a/src/act.obj2.c
+++ b/src/act.obj2.c
@@ -13,6 +13,7 @@
 #include <ctype.h>
 
 #include "protos.h"
+#include "utility.h"
 
 /* extern variables */
 
@@ -26,18 +27,15 @@ extern struct skill_data skill_info[];
 void weight_change_object(struct obj_data *obj, int weight) {
   struct obj_data *tmp_obj;
   struct char_data *tmp_ch;
-  char buf[255];
 
   if (GET_OBJ_WEIGHT(obj) + weight < 1) {
     weight = 0 - (GET_OBJ_WEIGHT(obj) - 1);
     if (obj->carried_by) {
-      SPRINTF(buf, "Bad weight change on %s, carried by %s.", obj->name,
-              obj->carried_by->player.name);
-      log_msg(buf);
+      log_msgf("Bad weight change on %s, carried by %s.", obj->name,
+               obj->carried_by->player.name);
     }
     else {
-      SPRINTF(buf, "Bad weight change on %s.", obj->name);
-      log_msg(buf);
+      log_msgf("Bad weight change on %s.", obj->name);
     }
   }
 

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -11,6 +11,7 @@
 
 #include "protos.h"
 #include "act.off.h"
+#include "utility.h"
 
 /* extern variables */
 
@@ -1357,7 +1358,7 @@ cast_geyser, cast_fire_breath, cast_gas_breath, cast_frost_breath,
 
 void do_breath(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   struct char_data *victim;
-  char buf[MAX_STRING_LENGTH], name[MAX_STRING_LENGTH];
+  char name[MAX_STRING_LENGTH];
   int count, manacost;
   void (*weapon) (byte, struct char_data *, char *, int, struct char_data *,
                   struct obj_data *);
@@ -1384,8 +1385,7 @@ void do_breath(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     for (count = 0; scan->breaths[count]; count++);
 
     if (count < 1) {
-      SPRINTF(buf, "monster %s has no breath weapons", ch->player.short_descr);
-      log_msg(buf);
+      log_msgf("monster %s has no breath weapons", ch->player.short_descr);
       send_to_char("Hey, why don't you have any breath weapons!?\n\r", ch);
       return;
     }

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -11,6 +11,7 @@
 #include <ctype.h>
 
 #include "protos.h"
+#include "utility.h"
 
 
 /* extern variables */
@@ -176,7 +177,6 @@ void do_title(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 
 void do_quit(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
   void die(struct char_data *ch);
-  char buf[256];
 
   if (IS_NPC(ch) || !ch->desc || IS_AFFECTED(ch, AFF_CHARM))
     return;
@@ -188,8 +188,7 @@ void do_quit(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
 
   if (GET_POS(ch) < POSITION_STUNNED) {
     send_to_char("You die before your time!\n\r", ch);
-    SPRINTF(buf, "%s dies via quit.", GET_NAME(ch));
-    log_msg(buf);
+    log_msgf("%s dies via quit.", GET_NAME(ch));
     die(ch);
     return;
   }
@@ -448,9 +447,8 @@ void do_steal(struct char_data *ch, char *argument, int UNUSED(cmd)) {
 
   if (get_max_level(victim) > 50) {
     send_to_char("Steal from a God?!?  Oh the thought!\n\r", ch);
-    SPRINTF(buf, "BUG NOTE: %s tried to steal from GOD %s", GET_NAME(ch),
-            GET_NAME(victim));
-    log_msg(buf);
+    log_msgf("BUG NOTE: %s tried to steal from GOD %s", GET_NAME(ch),
+             GET_NAME(victim));
     return;
   }
 

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -18,6 +18,7 @@
 
 #include "protos.h"
 #include "act.wizard.h"
+#include "utility.h"
 
 /*   external vars  */
 
@@ -516,7 +517,6 @@ void do_listhosts(struct char_data *UNUSED(ch), char *UNUSED(argument),
 }
 
 void do_silence(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
-  char buf[255];
   extern int Silence;
   if ((get_max_level(ch) < DEMIGOD) || (IS_NPC(ch))) {
     send_to_char("You cannot Silence.\n\r", ch);
@@ -526,16 +526,14 @@ void do_silence(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
   if (Silence == 0) {
     Silence = 1;
     send_to_char("You have now silenced polyed mobles.\n\r", ch);
-    SPRINTF(buf, "%s has stopped Polymophed characters from shouting.",
-            ch->player.name);
-    log_msg(buf);
+    log_msgf("%s has stopped Polymophed characters from shouting.",
+             ch->player.name);
   }
   else {
     Silence = 0;
     send_to_char("You have now unsilenced mobles.\n\r", ch);
-    SPRINTF(buf, "%s has allowed Polymophed characters to shout.",
-            ch->player.name);
-    log_msg(buf);
+    log_msgf("%s has allowed Polymophed characters to shout.",
+             ch->player.name);
   }
 }
 
@@ -621,9 +619,8 @@ void do_wizlock(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
       }
     }
     strcpy(hostlist[numberhosts], buf);
-    SPRINTF(buf, "%s has added host %s to the access denied list.",
-            GET_NAME(ch), hostlist[numberhosts]);
-    log_msg(buf);
+    log_msgf("%s has added host %s to the access denied list.",
+             GET_NAME(ch), hostlist[numberhosts]);
     numberhosts++;
     return;
 
@@ -659,9 +656,8 @@ void do_wizlock(struct char_data *ch, char *UNUSED(argument), int UNUSED(cmd)) {
       if (strncmp(hostlist[a], buf, length) == 0) {
         for (b = a; b <= numberhosts; b++)
           strcpy(hostlist[b], hostlist[b + 1]);
-        SPRINTF(buf, "%s has removed host %s from the access denied list.",
-                GET_NAME(ch), hostlist[numberhosts]);
-        log_msg(buf);
+        log_msgf("%s has removed host %s from the access denied list.",
+                 GET_NAME(ch), hostlist[numberhosts]);
         numberhosts--;
         return;
       }
@@ -1848,17 +1844,15 @@ void do_set(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     if (PeacefulWorks) {
       PeacefulWorks = FALSE;
       EasySummon = FALSE;
-      SPRINTF(buf, "Peaceful rooms and Easy Summon disabled by %s",
-              GET_NAME(ch));
+      log_msgf("Peaceful rooms and Easy Summon disabled by %s",
+               GET_NAME(ch));
     }
     else {
       PeacefulWorks = TRUE;
       EasySummon = TRUE;
-      SPRINTF(buf, "Peaceful rooms and Easy Summon enabled by %s",
-              GET_NAME(ch));
+      log_msgf("Peaceful rooms and Easy Summon enabled by %s",
+               GET_NAME(ch));
     }
-    log_msg(buf);
-
   }
   else if (!strcmp(field, "mana")) {
     sscanf(parmstr, "%d", &parm);
@@ -1938,10 +1932,10 @@ void do_snoop(struct char_data *ch, char *argument, int UNUSED(cmd)) {
       if (ch->desc->snoop.snooping->desc)
         ch->desc->snoop.snooping->desc->snoop.snoop_by = 0;
       else {
-        char buf[MAX_STRING_LENGTH];
-        SPRINTF(buf, "caught %s snooping %s who didn't have a descriptor!",
-                ch->player.name, ch->desc->snoop.snooping->player.name);
-        log_msg(buf);
+        log_msgf(
+          "caught %s snooping %s who didn't have a descriptor!",
+          ch->player.name,
+          ch->desc->snoop.snooping->player.name);
 /*
 logically.. this person has returned from being a creature? 
 */

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -86,16 +86,14 @@ void do_auth(struct char_data *ch, char *argument, int cmd) {
     one_argument(argument, word);
     if (str_cmp(word, "yes") == 0) {
       d->character->generic = NEWBIE_START;
-      SPRINTF(buf2, "%s has just accepted %s into the game.",
-              ch->player.name, name);
-      log_msg(buf2);
+      log_msgf("%s has just accepted %s into the game.",
+               ch->player.name, name);
       SEND_TO_Q("You have been accepted.  Press enter\n\r", d);
     }
     else if (str_cmp(word, "no") == 0) {
       SEND_TO_Q("You have been denied.  Press enter\n\r", d);
-      SPRINTF(buf2, "%s has just denied %s from the game.",
-              ch->player.name, name);
-      log_msg(buf2);
+      log_msgf("%s has just denied %s from the game.",
+               ch->player.name, name);
       d->character->generic = NEWBIE_AXE;
     }
     else {

--- a/src/board.c
+++ b/src/board.c
@@ -13,6 +13,8 @@
 
 #include "protos.h"
 #include "db.h"
+#include "utility.h"
+
 
 #define MAX_MSGS 99             /* Max number of messages.          */
 #define MAX_MESSAGE_LENGTH 2048 /* that should be enough            */
@@ -342,8 +344,6 @@ void board_save_board(int bnum) {
   fclose(the_file);
   return;
 }
-
-#include "utility.h"
 
 void board_load_board() {
 

--- a/src/board.c
+++ b/src/board.c
@@ -343,6 +343,8 @@ void board_save_board(int bnum) {
   return;
 }
 
+#include "utility.h"
+
 void board_load_board() {
 
   FILE *the_file;
@@ -370,7 +372,7 @@ void board_load_board() {
     }
 
     if (EOF == fscanf(the_file, " %d ", &boards[bnum].number)) {
-      log_msg("Board-message file is emptyish.");
+      log_msgf("Board-message file %s is emptyish.", save_file[bnum]);
     }
     else if (boards[bnum].number < 0 || boards[bnum].number > MAX_MSGS ||
         feof(the_file)) {

--- a/src/board.c
+++ b/src/board.c
@@ -350,7 +350,6 @@ void board_load_board() {
   FILE *the_file;
   int ind;
   int bnum;
-  char buf[256];
 
   memset(boards, 0, sizeof(boards));    /* Zero out the array, make sure no */
   /* Funky pointers are left in the   */
@@ -366,8 +365,7 @@ void board_load_board() {
     boards[bnum].number = -1;
     the_file = fopen(save_file[bnum], "r");
     if (!the_file) {
-      SPRINTF(buf, "Can't open message file for board %d.\n\r", bnum);
-      log_msg(buf);
+      log_msgf("Can't open message file for board %d.\n\r", bnum);
       continue;
     }
 

--- a/src/comm.c
+++ b/src/comm.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include "protos.h"
+#include "utility.h"
 
 #define DFLT_PORT 4000          /* default port */
 #define MAX_NAME_LENGTH 15
@@ -94,7 +95,7 @@ void close_socket_fd(int desc) {
 
 int real_main(int argc, char **argv) {
   int port, pos = 1;
-  char buf[512], *dir;
+  char *dir;
 
   extern int WizLock;
 #ifdef sun
@@ -141,8 +142,7 @@ int real_main(int argc, char **argv) {
       log_msg("Suppressing assignment of special routines.");
       break;
     default:
-      SPRINTF(buf, "Unknown option -% in argument string.", *(argv[pos] + 1));
-      log_msg(buf);
+      log_msgf("Unknown option -% in argument string.", *(argv[pos] + 1));
       break;
     }
     pos++;
@@ -164,16 +164,14 @@ int real_main(int argc, char **argv) {
 
   Uptime = time(0);
 
-  SPRINTF(buf, "Running game on port %d.", port);
-  log_msg(buf);
+  log_msgf("Running game on port %d.", port);
 
   if (chdir(dir) < 0) {
     perror("chdir");
     assert(0);
   }
 
-  SPRINTF(buf, "Using %s as data directory.", dir);
-  log_msg(buf);
+  log_msgf("Using %s as data directory.", dir);
 
   srandom(time(0));
   WizLock = FALSE;
@@ -1039,7 +1037,6 @@ void close_sockets(int s) {
 
 void close_socket(struct descriptor_data *d) {
   struct descriptor_data *tmp;
-  char buf[100];
   struct txt_block *txt, *txt2;
 
   void do_save(struct char_data *ch, char *argument, int cmd);
@@ -1065,8 +1062,7 @@ void close_socket(struct descriptor_data *d) {
     if (d->connected == CON_PLYNG) {
       do_save(d->character, "", 0);
       act("$n has lost $s link.", TRUE, d->character, 0, 0, TO_ROOM);
-      SPRINTF(buf, "Closing link to: %s.", GET_NAME(d->character));
-      log_msg(buf);
+      log_msgf("Closing link to: %s.", GET_NAME(d->character));
       if (IS_NPC(d->character)) {       /* poly, or switched god */
         if (d->character->desc)
           d->character->orig = d->character->desc->original;
@@ -1083,8 +1079,7 @@ void close_socket(struct descriptor_data *d) {
     }
     else {
       if (GET_NAME(d->character)) {
-        SPRINTF(buf, "Losing player: %s.", GET_NAME(d->character));
-        log_msg(buf);
+        log_msgf("Losing player: %s.", GET_NAME(d->character));
       }
       free_char(d->character);
     }

--- a/src/comm.c
+++ b/src/comm.c
@@ -1485,8 +1485,7 @@ void act(char *str, int hide_invisible, struct char_data *ch,
             i = "$";
             break;
           default:
-            log_msg("Illegal $-code to act():");
-            log_msg(str);
+            log_msgf("Illegal $-code to act(): %s", str);
             break;
           }
 

--- a/src/db.c
+++ b/src/db.c
@@ -17,6 +17,7 @@
 
 #include "protos.h"
 #include "db.h"
+#include "utility.h"
 
 #define NEW_ZONE_SYSTEM
 
@@ -225,7 +226,6 @@ void boot_db() {
 /* reset the time in the game from file */
 /* reset the time in the game from file */
 void reset_time() {
-  char buf[80];
   extern unsigned char moontype;
   long beginning_of_time = 650336715;
 
@@ -288,9 +288,8 @@ void reset_time() {
     }
   }
 
-  SPRINTF(buf, "   Current Gametime: %dH %dD %dM %dY.",
-          time_info.hours, time_info.day, time_info.month, time_info.year);
-  log_msg(buf);
+  log_msgf("   Current Gametime: %dH %dD %dM %dY.",
+           time_info.hours, time_info.day, time_info.month, time_info.year);
 
   weather_info.pressure = 960;
   if ((time_info.month >= 7) && (time_info.month <= 12))
@@ -384,10 +383,9 @@ void build_player_index() {
 
       for (i = 0; i <= 5; i++)
         if (dummy.level[i] >= 51) {
-          SPRINTF(buf, "GOD: %s, Levels [%d][%d][%d][%d][%d][%d]", dummy.name,
-                  dummy.level[0], dummy.level[1], dummy.level[2],
-                  dummy.level[3], dummy.level[4], dummy.level[5]);
-          log_msg(buf);
+          log_msgf("GOD: %s, Levels [%d][%d][%d][%d][%d][%d]", dummy.name,
+                   dummy.level[0], dummy.level[1], dummy.level[2],
+                   dummy.level[3], dummy.level[4], dummy.level[5]);
 
           max = 0;
           for (j = 0; j < MAX_CLASS; j++)
@@ -813,7 +811,6 @@ void load_one_room(FILE * fl, struct room_data *rp) {
   rp->ex_description = 0;
 
   while (1 == fscanf(fl, " %s \n", chk)) {
-    static char buf[MAX_INPUT_LENGTH];
     switch (*chk) {
     case 'D':
       setup_dir(fl, rp->number, atoi(chk + 1));
@@ -852,9 +849,8 @@ void load_one_room(FILE * fl, struct room_data *rp) {
       room_count++;
       return;
     default:
-      SPRINTF(buf, "unknown auxiliary code `%s' in room load of #%d",
-              chk, rp->number);
-      log_msg(buf);
+      log_msgf("unknown auxiliary code `%s' in room load of #%d",
+               chk, rp->number);
       break;
     }
   }
@@ -974,15 +970,13 @@ void setup_dir(FILE * fl, int room, int dir) {
 }
 
 
-#define LOG_ZONE_ERROR(ch, type, zone, cmd) {\
-	SPRINTF(buf, "error in zone %s cmd %d (%c) resolving %s number", \
-		zone_table[zone].name, cmd, ch, type); \
-		  log_msg(buf); \
+#define LOG_ZONE_ERROR(ch, type, zone, cmd) {                       \
+	log_msgf("error in zone %s cmd %d (%c) resolving %s number",    \
+             zone_table[zone].name, cmd, ch, type);                 \
 		  }
 void renum_zone_table() {
   int zone, comm;
   struct reset_com *cmd;
-  char buf[256];
 
   for (zone = 0; zone <= top_of_zone_table; zone++)
     for (comm = 0; zone_table[zone].cmd[comm].command != 'S'; comm++)
@@ -1609,10 +1603,8 @@ struct char_data *read_mobile(int nr, int type) {
 #endif
 
   if (mob->points.gold > GET_LEVEL(mob, WARRIOR_LEVEL_IND) * 1500) {
-    char buf[200];
-    SPRINTF(buf, "%s has gold > level * 1500 (%d)", mob->player.short_descr,
-            mob->points.gold);
-    log_msg(buf);
+    log_msgf("%s has gold > level * 1500 (%d)", mob->player.short_descr,
+             mob->points.gold);
   }
 
   /* set up things that all members of the race have */
@@ -1916,8 +1908,7 @@ void reset_zone(int zone) {
     s = zone_table[zone].name;
     d = (zone ? (zone_table[zone - 1].top + 1) : 0);
     e = zone_table[zone].top;
-    SPRINTF(buf, "Run time initialization of zone %s, rooms (%d-%d)", s, d, e);
-    log_msg(buf);
+    log_msgf("Run time initialization of zone %s, rooms (%d-%d)", s, d, e);
 
   }
 
@@ -2015,8 +2006,7 @@ void reset_zone(int zone) {
             }
           }
           else if ((obj = read_object(ZCMD.arg1, REAL)) != NULL) {
-            SPRINTF(buf, "Error finding room #%d", ZCMD.arg3);
-            log_msg(buf);
+            log_msgf("Error finding room #%d", ZCMD.arg3);
             last_cmd = 1;
           }
           else {
@@ -2114,9 +2104,8 @@ void reset_zone(int zone) {
         break;
 
       default:
-        SPRINTF(buf, "Undefd cmd [%c] in reset table; zone %d cmd %d.",
-                ZCMD.command, zone, cmd_no);
-        log_msg(buf);
+        log_msgf("Undefd cmd [%c] in reset table; zone %d cmd %d.",
+                 ZCMD.command, zone, cmd_no);
         break;
       }
     else
@@ -2744,7 +2733,6 @@ void clear_dead_bit(struct char_data *ch) {
 
 /* clear some of the the working variables of a char */
 void reset_char(struct char_data *ch) {
-  char buf[100];
   struct affected_type *af;
   extern struct dex_app_type dex_app[];
 
@@ -2822,12 +2810,10 @@ void reset_char(struct char_data *ch) {
   }
 
   if (GET_BANK(ch) > get_max_level(ch) * 100000) {
-    SPRINTF(buf, "%s has %d coins in bank.", GET_NAME(ch), GET_BANK(ch));
-    log_msg(buf);
+    log_msgf("%s has %d coins in bank.", GET_NAME(ch), GET_BANK(ch));
   }
   if (GET_GOLD(ch) > get_max_level(ch) * 100000) {
-    SPRINTF(buf, "%s has %d coins.", GET_NAME(ch), GET_GOLD(ch));
-    log_msg(buf);
+    log_msgf("%s has %d coins.", GET_NAME(ch), GET_GOLD(ch));
   }
 
   /*
@@ -3233,16 +3219,14 @@ void init_scripts() {
       char garbage[4];
       strncpy(garbage, buf, 3);
       garbage[3] = '\0';
-      SPRINTF(buf, "%s read in, garbage.", garbage);
-      log_msg(buf);
+      log_msgf("%s read in, garbage.", garbage);
     }
 
     sscanf(buf, "%s %d", buf2, &i);
 
     SPRINTF(buf, "scripts/%s", buf2);
     if (!(f2 = fopen(buf, "r"))) {
-      SPRINTF(buf, "Unable to open script \"%s\" for reading.", buf2);
-      log_msg(buf);
+      log_msgf("Unable to open script \"%s\" for reading.", buf2);
     }
 
     else {
@@ -3283,18 +3267,16 @@ void init_scripts() {
       script_data[top_of_scripts].filename =
         (char *)malloc((strlen(buf2) + 1) * sizeof(char));
       strcpy(script_data[top_of_scripts].filename, buf2);
-      SPRINTF(buf, "Script %s assigned to mobile %d.", buf2, i);
-      log_msg(buf);
+      log_msgf("Script %s assigned to mobile %d.", buf2, i);
       top_of_scripts++;
       fclose(f2);
     }
   }
 
   if (top_of_scripts)
-    SPRINTF(buf, "%d scripts assigned.", top_of_scripts);
+    log_msgf("%d scripts assigned.", top_of_scripts);
   else
-    SPRINTF(buf, "No scripts found to assign.");
-  log_msg(buf);
+    log_msgf("No scripts found to assign.");
 
   fclose(f1);
 }
@@ -3528,8 +3510,7 @@ void read_text_zone(FILE * fl) {
             }
           }
           else if ((obj = read_object(i, VIRTUAL)) != NULL) {
-            SPRINTF(buf, "Error finding room #%d", k);
-            log_msg(buf);
+            log_msgf("Error finding room #%d", k);
             last_cmd = 1;
           }
           else {
@@ -3703,9 +3684,8 @@ void clean_playerfile() {
       num_processed++;
       grunt.AXE = FALSE;
       if (!str_cmp(grunt.dummy.name, "111111")) {
-        SPRINTF(buf, "%s was deleted (111111 name hopefully).",
-                grunt.dummy.name);
-        log_msg(buf);
+        log_msgf("%s was deleted (111111 name hopefully).",
+                 grunt.dummy.name);
         ones++;
         num_deleted++;
         grunt.AXE = TRUE;
@@ -3727,17 +3707,15 @@ void clean_playerfile() {
               (long)j * (SECS_PER_REAL_DAY * 30)) {
             num_deleted++;
             grunt.AXE = TRUE;
-            SPRINTF(buf, "%s deleted after %d months of inactivity.",
-                    grunt.dummy.name, j);
-            log_msg(buf);
+            log_msgf("%s deleted after %d months of inactivity.",
+                     grunt.dummy.name, j);
           }
         }
         else if (max > LOW_IMMORTAL) {
           if (timeH - grunt.dummy.last_logon > (long)SECS_PER_REAL_DAY * 30) {
             num_demoted++;
-            SPRINTF(buf, "%s demoted from %d to %d due to inactivity.",
-                    grunt.dummy.name, max, max - 1);
-            log_msg(buf);
+            log_msgf("%s demoted from %d to %d due to inactivity.",
+                     grunt.dummy.name, max, max - 1);
             grunt.dummy.last_logon = timeH;     /* so it doesn't happen twice */
             max--;
             max = MAX(51, max); /* should not be necessary */
@@ -3753,14 +3731,10 @@ void clean_playerfile() {
     }
   }
 
-  SPRINTF(buf, "-- %d characters were processed.", num_processed);
-  log_msg(buf);
-  SPRINTF(buf, "-- %d characters were deleted.  ", num_deleted);
-  log_msg(buf);
-  SPRINTF(buf, "-- %d of these were allread deleted. (11111s)", ones);
-  log_msg(buf);
-  SPRINTF(buf, "-- %d gods were demoted due to inactivity.", num_demoted);
-  log_msg(buf);
+  log_msgf("-- %d characters were processed.", num_processed);
+  log_msgf("-- %d characters were deleted.  ", num_deleted);
+  log_msgf("-- %d of these were allread deleted. (11111s)", ones);
+  log_msgf("-- %d gods were demoted due to inactivity.", num_demoted);
   SPRINTF(buf, "mv %s %s.bak", PLAYER_FILE, PLAYER_FILE);
   system(buf);
   SPRINTF(buf, "mv temp %s", PLAYER_FILE);
@@ -3778,14 +3752,7 @@ void ensure_file_exists(const char *path) {
     return;
   if (errno == ENOENT) {
     int fd;
-    {
-      char *buf;
-      const char *fmt = "Creating empty file \"%s\"";
-      buf = (char *)malloc(strlen(path) + strlen(fmt) - 1);
-      SPRINTF(buf, fmt, path);
-      log_msg(buf);
-      free(buf);
-    }
+    log_msgf("Creating empty file \"%s\"", path);
     if ((fd = open(path, O_CREAT | O_WRONLY, 0644)) == -1) {
       char *buf;
       const char *fmt = "ensure_file_exists(%s)(open)";

--- a/src/fight.c
+++ b/src/fight.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 
 #include "protos.h"
+#include "utility.h"
 
 #define DUAL_WIELD(ch) (ch->equipment[WIELD] && ch->equipment[HOLD]&&\
 			ITEM_TYPE(ch->equipment[WIELD])==ITEM_WEAPON && \
@@ -884,15 +885,13 @@ void dam_message(int dam, struct char_data *ch, struct char_data *victim,
 
 int dam_check_deny(struct char_data *ch, struct char_data *victim, int type) {
   struct room_data *rp;
-  char buf[MAX_INPUT_LENGTH];
 
   assert(GET_POS(victim) > POSITION_DEAD);
 
   rp = real_roomp(ch->in_room);
   if (rp && (rp->room_flags & PEACEFUL) && type != SPELL_POISON &&
       type != SPELL_HEAT_STUFF) {
-    SPRINTF(buf, "damage(,,,%d) called in PEACEFUL room", type);
-    log_msg(buf);
+    log_msgf("damage(,,,%d) called in PEACEFUL room", type);
     return (TRUE);              /* true, they are denied from fighting */
   }
   return (FALSE);
@@ -1560,21 +1559,18 @@ int Getw_type(struct obj_data *wielded) {
 
 int hit_check_deny(struct char_data *ch, struct char_data *victim) {
   struct room_data *rp;
-  char buf[256];
   extern char PeacefulWorks;
 
   rp = real_roomp(ch->in_room);
   if (rp && rp->room_flags & PEACEFUL && PeacefulWorks) {
-    SPRINTF(buf, "hit() called in PEACEFUL room");
-    log_msg(buf);
+    log_msgf("hit() called in PEACEFUL room");
     stop_fighting(ch);
     return (TRUE);
   }
 
   if (ch->in_room != victim->in_room) {
-    SPRINTF(buf, "NOT in same room when fighting : %s, %s", ch->player.name,
-            victim->player.name);
-    log_msg(buf);
+    log_msgf("NOT in same room when fighting : %s, %s", ch->player.name,
+             victim->player.name);
     stop_fighting(ch);
     return (TRUE);
   }
@@ -1841,7 +1837,6 @@ int get_weapon_dam(struct char_data *ch, struct char_data *v,
 
 int get_backstab_mult(struct char_data *ch, struct char_data *v) {
   int mult, our_skill;
-  char buf[80];
 
   if (GET_LEVEL(ch, THIEF_LEVEL_IND)) {
     mult = backstab_mult[(int)GET_LEVEL(ch, THIEF_LEVEL_IND)];
@@ -1944,9 +1939,8 @@ int get_backstab_mult(struct char_data *ch, struct char_data *v) {
   }
 
   if (!our_skill) {
-    SPRINTF(buf, "Warning, race %d was unaccounted for in get_backstab_mult()",
-            GET_RACE(v));
-    log_msg(buf);
+    log_msgf("Warning, race %d was unaccounted for in get_backstab_mult()",
+             GET_RACE(v));
     return (mult);
   }
 
@@ -1976,7 +1970,6 @@ int get_backstab_mult(struct char_data *ch, struct char_data *v) {
 
 void hit_victim(struct char_data *ch, struct char_data *v, int dam,
                 int type, int w_type, int (*dam_func) ()) {
-  char buf[80];
   extern byte backstab_mult[];
   int dead;
 
@@ -1984,9 +1977,9 @@ void hit_victim(struct char_data *ch, struct char_data *v, int dam,
     int tmp;
 
     tmp = get_backstab_mult(ch, v);
-    SPRINTF(buf, "BS multiplier for %dth level char is %d.", get_max_level(ch),
-            tmp);
-    log_msg(buf);
+    log_msgf("BS multiplier for %dth level char is %d.",
+             get_max_level(ch),
+             tmp);
     dam *= tmp;
     dead = (*dam_func) (ch, v, dam, type);
 
@@ -2112,11 +2105,9 @@ void perform_violence() {
 
     rp = real_roomp(ch->in_room);
     if (rp && rp->room_flags & PEACEFUL) {
-      char buf[MAX_INPUT_LENGTH];
-      SPRINTF(buf, "perform_violence() found %s fighting in a PEACEFUL room.",
-              ch->player.name);
       stop_fighting(ch);
-      log_msg(buf);
+      log_msgf("perform_violence() found %s fighting in a PEACEFUL room.",
+               ch->player.name);
     }
     else if (ch == ch->specials.fighting) {
       stop_fighting(ch);

--- a/src/handler.c
+++ b/src/handler.c
@@ -433,9 +433,9 @@ void affect_modify(struct char_data *ch, byte loc, long mod, long bitv,
     break;
 
   default:
-    log_msg("Unknown apply adjust attempt (handler.c, affect_modify).");
-    log_msg(ch->player.name);
-
+    log_msgf(
+      "Unknown apply adjust attempt (handler.c, affect_modify).: %s",
+      ch->player.name);
     break;
 
   }                             /* switch */
@@ -530,8 +530,8 @@ void affect_remove(struct char_data *ch, struct affected_type *af) {
   struct affected_type *hjp;
 
   if (!ch->affected) {
-    log_msg("affect removed from char without affect");
-    log_msg(GET_NAME(ch));
+    log_msgf("affect removed from char without affect: %s",
+             GET_NAME(ch));
     return;
   }
 
@@ -1320,9 +1320,9 @@ void extract_obj(struct obj_data *obj) {
 
     }
     else {
-      log_msg("Extract on equipped item in slot -1 on:");
-      log_msg(obj->equipped_by->player.name);
-      log_msg(obj->name);
+      log_msgf("Extract on equipped item in slot -1 on: %s %s",
+               obj->equipped_by->player.name,
+               obj->name);
       return;
     }
   }

--- a/src/handler.c
+++ b/src/handler.c
@@ -13,6 +13,7 @@
 
 #include "protos.h"
 #include "act.wizard.h"
+#include "utility.h"
 
 #if HASH
 extern struct hash_header room_db;
@@ -616,7 +617,6 @@ void affect_join(struct char_data *ch, struct affected_type *af,
 
 /* move a player out of a room */
 void char_from_room(struct char_data *ch) {
-  char buf[MAX_INPUT_LENGTH];
   struct char_data *i;
   struct room_data *rp;
 
@@ -632,10 +632,9 @@ void char_from_room(struct char_data *ch) {
 
   rp = real_roomp(ch->in_room);
   if (rp == NULL) {
-    SPRINTF(buf, "ERROR: char_from_room: %s was not in a valid room (%d)",
-            (!IS_NPC(ch) ? (ch)->player.name : (ch)->player.short_descr),
-            ch->in_room);
-    log_msg(buf);
+    log_msgf("ERROR: char_from_room: %s was not in a valid room (%d)",
+             (!IS_NPC(ch) ? (ch)->player.name : (ch)->player.short_descr),
+             ch->in_room);
     return;
   }
 
@@ -647,10 +646,9 @@ void char_from_room(struct char_data *ch) {
     if (i)
       i->next_in_room = ch->next_in_room;
     else {
-      SPRINTF(buf, "SHIT, %s was not in people list of his room %d!",
-              (!IS_NPC(ch) ? (ch)->player.name : (ch)->player.short_descr),
-              ch->in_room);
-      log_msg(buf);
+      log_msgf("SHIT, %s was not in people list of his room %d!",
+               (!IS_NPC(ch) ? (ch)->player.name : (ch)->player.short_descr),
+               ch->in_room);
     }
   }
 
@@ -1241,21 +1239,17 @@ void obj_to_obj(struct obj_data *obj, struct obj_data *obj_to) {
 /* remove an object from an object */
 void obj_from_obj(struct obj_data *obj) {
   struct obj_data *tmp, *obj_from;
-  char buf[100];
 
   if (obj->carried_by) {
-    SPRINTF(buf, "%s carried by %s in obj_from_obj\n", obj->name,
-            obj->carried_by->player.name);
-    log_msg(buf);
+    log_msgf("%s carried by %s in obj_from_obj\n", obj->name,
+             obj->carried_by->player.name);
   }
   if (obj->equipped_by) {
-    SPRINTF(buf, "%s equipped by %s in obj_from_obj\n", obj->name,
-            obj->equipped_by->player.name);
-    log_msg(buf);
+    log_msgf("%s equipped by %s in obj_from_obj\n", obj->name,
+             obj->equipped_by->player.name);
   }
   if (obj->in_room != NOWHERE) {
-    SPRINTF(buf, "%s in room %d in obj_from_obj\n", obj->name, obj->in_room);
-    log_msg(buf);
+    log_msgf("%s in room %d in obj_from_obj\n", obj->name, obj->in_room);
   }
 
   assert(!obj->carried_by && !obj->equipped_by && obj->in_room == NOWHERE);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include "protos.h"
+#include "utility.h"
 
 #define NOT !
 #define AND &&
@@ -1311,15 +1312,13 @@ void nanny(struct descriptor_data *d, char *arg) {
           STATE(d) = CON_PLYNG;
 
           act("$n has reconnected.", TRUE, tmp_ch, 0, 0, TO_ROOM);
-          SPRINTF(buf, "%s[%s] has reconnected.",
-                  GET_NAME(d->character), d->host);
-          log_msg(buf);
+          log_msgf("%s[%s] has reconnected.",
+                   GET_NAME(d->character), d->host);
           return;
         }
 
 
-      SPRINTF(buf, "%s[%s] has connected.", GET_NAME(d->character), d->host);
-      log_msg(buf);
+      log_msgf("%s[%s] has connected.", GET_NAME(d->character), d->host);
       SEND_TO_Q(motd, d);
       SEND_TO_Q("\n\r\n*** PRESS RETURN: ", d);
 
@@ -1658,8 +1657,8 @@ void nanny(struct descriptor_data *d, char *arg) {
         SEND_TO_Q("***PRESS ENTER**", d);
 #else
         if (STATE(d) != CON_QCLASS) {
-          SPRINTF(buf, "%s [%s] new player.", GET_NAME(d->character), d->host);
-          log_msg(buf);
+          log_msgf("%s [%s] new player.", GET_NAME(d->character),
+                   d->host);
           /*
            ** now that classes are set, initialize
            */
@@ -1789,8 +1788,7 @@ void nanny(struct descriptor_data *d, char *arg) {
       case '1':
 
         reset_char(d->character);
-        SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
-        log_msg(buf);
+        log_msgf("Loading %s's equipment", d->character->player.name);
         load_char_objs(d->character);
         save_char(d->character, AUTO_RENT);
         send_to_char(WELC_MESSG, d->character);
@@ -1816,8 +1814,7 @@ void nanny(struct descriptor_data *d, char *arg) {
       case '2':
 
         reset_char(d->character);
-        SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
-        log_msg(buf);
+        log_msgf("Loading %s's equipment", d->character->player.name);
         load_char_objs(d->character);
         save_char(d->character, AUTO_RENT);
         send_to_char(WELC_MESSG, d->character);
@@ -1843,8 +1840,8 @@ void nanny(struct descriptor_data *d, char *arg) {
         if (get_max_level(d->character) > 5) {
 
           reset_char(d->character);
-          SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
-          log_msg(buf);
+          log_msgf("Loading %s's equipment",
+                   d->character->player.name);
           load_char_objs(d->character);
           save_char(d->character, AUTO_RENT);
           send_to_char(WELC_MESSG, d->character);
@@ -1876,8 +1873,8 @@ void nanny(struct descriptor_data *d, char *arg) {
         if (get_max_level(d->character) > 5) {
 
           reset_char(d->character);
-          SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
-          log_msg(buf);
+          log_msgf("Loading %s's equipment",
+                   d->character->player.name);
           load_char_objs(d->character);
           save_char(d->character, AUTO_RENT);
           send_to_char(WELC_MESSG, d->character);
@@ -1909,8 +1906,8 @@ void nanny(struct descriptor_data *d, char *arg) {
         if (get_max_level(d->character) > 5) {
 
           reset_char(d->character);
-          SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
-          log_msg(buf);
+          log_msgf("Loading %s's equipment",
+                   d->character->player.name);
           load_char_objs(d->character);
           save_char(d->character, AUTO_RENT);
           send_to_char(WELC_MESSG, d->character);
@@ -1956,8 +1953,7 @@ void nanny(struct descriptor_data *d, char *arg) {
 
     case '1':
       reset_char(d->character);
-      SPRINTF(buf, "Loading %s's equipment", d->character->player.name);
-      log_msg(buf);
+      log_msgf("Loading %s's equipment", d->character->player.name);
       load_char_objs(d->character);
       save_char(d->character, AUTO_RENT);
       send_to_char(WELC_MESSG, d->character);

--- a/src/intrinsics.c
+++ b/src/intrinsics.c
@@ -10,6 +10,7 @@
 #include <ctype.h>
 
 #include "protos.h"
+#include "utility.h"
 
 extern struct time_info_data time_info; /* In db.c */
 extern unsigned char moontype;
@@ -49,8 +50,7 @@ void do_changeform(struct char_data *ch, char *argument, int UNUSED(cmd)) {
   level = GET_LEVEL(ch, DRUID_LEVEL_IND);
 
   level = (level ? level : get_max_level(ch));  /* for vampires */
-  SPRINTF(buf, "Level %d thing doing a changeform.", level);
-  log_msg(buf);
+  log_msgf("Level %d thing doing a changeform.", level);
 
   one_argument(argument, buf);
 

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -13,6 +13,7 @@
 
 #include "protos.h"
 #include "act.move.h"
+#include "utility.h"
 
 /* Extern structures */
 extern struct room_data *world;
@@ -2261,9 +2262,7 @@ void spell_portal(byte level, struct char_data *ch,
   }
 
   if (!(nrp = real_roomp(tmp_ch->in_room))) {
-    char str[180];
-    SPRINTF(str, "%s not in any room.", GET_NAME(tmp_ch));
-    log_msg(str);
+    log_msgf("%s not in any room.", GET_NAME(tmp_ch));
     send_to_char("Your magic cannot locate the target.\n\r", ch);
     return;
   }

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 extern struct char_data *character_list;
 extern struct index_data *mob_index;
@@ -287,10 +288,8 @@ void mobile_activity(struct char_data *ch) {
   if (((IS_SET(ch->specials.act, ACT_SPEC) || mob_index[ch->nr].func))
       && !no_specials) {
     if (!mob_index[ch->nr].func) {
-      char buf[180];
-      SPRINTF(buf, "Attempting to call a non-existing mob func on %s",
-              GET_NAME(ch));
-      log_msg(buf);
+      log_msgf("Attempting to call a non-existing mob func on %s",
+               GET_NAME(ch));
       REMOVE_BIT(ch->specials.act, ACT_SPEC);
     }
     else {
@@ -465,7 +464,6 @@ int same_race(struct char_data *ch1, struct char_data *ch2) {
 int assist_friend(struct char_data *ch) {
   struct char_data *damsel, *targ, *tmp_ch, *next;
   int t, found;
-  char buf[256];
 
   damsel = 0;
   targ = 0;
@@ -473,8 +471,7 @@ int assist_friend(struct char_data *ch) {
   if (check_peaceful(ch, ""))
     return (0);
   if (ch->in_room < 0) {
-    SPRINTF(buf, "Mob %s in negative room", ch->player.name);
-    log_msg(buf);
+    log_msgf("Mob %s in negative room", ch->player.name);
     ch->in_room = 0;
     extract_char(ch);
     return (0);
@@ -809,7 +806,7 @@ void end2(char *UNUSED(arg), struct char_data *ch) {
 }
 
 void sgoto(char *arg, struct char_data *ch) {
-  char *p, buf[255];
+  char *p;
   struct char_data *mob;
   int dir, room;
 
@@ -832,9 +829,8 @@ void sgoto(char *arg, struct char_data *ch) {
     }
   }
   else {
-    SPRINTF(buf, "Error in script %s, no destination for goto",
-            script_data[ch->script].filename);
-    log_msg(buf);
+    log_msgf("Error in script %s, no destination for goto",
+             script_data[ch->script].filename);
     ch->commandp++;
     return;
   }
@@ -886,9 +882,8 @@ void do_jmp(char *arg, struct char_data *ch) {
     }
   }
 
-  SPRINTF(buf, "Label %s undefined in script assigned to %s.  Ignoring.", arg,
-          GET_NAME(ch));
-  log_msg(buf);
+  log_msgf("Label %s undefined in script assigned to %s.  Ignoring.",
+           arg, GET_NAME(ch));
 
   ch->commandp++;
 }
@@ -909,9 +904,8 @@ void do_jsr(char *arg, struct char_data *ch) {
     }
   }
 
-  SPRINTF(buf, "Label %s undefined in script assigned to %s.  Ignoring.", arg,
-          GET_NAME(ch));
-  log_msg(buf);
+  log_msgf("Label %s undefined in script assigned to %s.  Ignoring.",
+           arg, GET_NAME(ch));
 
   ch->commandp++;
 }

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -272,8 +272,8 @@ void mobile_activity(struct char_data *ch) {
 #else
   if ((ch->in_room < 0) || !room_find(&room_db, ch->in_room)) {
 #endif
-    log_msg("Char not in correct room.  moving to 50 ");
-    log_msg(GET_NAME(ch));
+    log_msgf("Char not in correct room.  moving to 50: %s", 
+             GET_NAME(ch));
     assert(ch->in_room >= 0);   /* if they are in a - room, assume an error */
     char_from_room(ch);
     char_to_room(ch, 50);

--- a/src/multiclass.c
+++ b/src/multiclass.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 
 /* extern variables */
@@ -130,8 +131,8 @@ int best_fighting_class(struct char_data *ch) {
   if (GET_LEVEL(ch, MAGE_LEVEL_IND))
     return (MAGE_LEVEL_IND);
 
-  log_msg("Massive error.. character has no recognized class.");
-  log_msg(GET_NAME(ch));
+  log_msgf("Massive error.. character has no recognized class.: %s",
+           GET_NAME(ch));
   assert(0);
 
   return (1);
@@ -152,8 +153,8 @@ int best_thief_class(struct char_data *ch) {
   if (GET_LEVEL(ch, CLERIC_LEVEL_IND))
     return (CLERIC_LEVEL_IND);
 
-  log_msg("Massive error.. character has no recognized class.");
-  log_msg(GET_NAME(ch));
+  log_msgf("Massive error.. character has no recognized class.: %s",
+           GET_NAME(ch));
   assert(0);
 
   return (1);
@@ -174,8 +175,8 @@ int best_magic_class(struct char_data *ch) {
   if (GET_LEVEL(ch, MONK_LEVEL_IND))
     return (MONK_LEVEL_IND);
 
-  log_msg("Massive error.. character has no recognized class.");
-  log_msg(GET_NAME(ch));
+  log_msgf("Massive error.. character has no recognized class.: %s", 
+           GET_NAME(ch));
   ch->player.class = 4;
 
   return (1);

--- a/src/reception.c
+++ b/src/reception.c
@@ -14,6 +14,7 @@
 
 #include "protos.h"
 #include "reception.h"
+#include "utility.h"
 
 #define OBJ_FILE_FREE "\0\0\0"
 
@@ -295,8 +296,7 @@ void load_char_objs(struct char_data *ch) {
     timegold = (int)((st.total_cost * ((float)time(0) - st.last_update)) /
                      (SECS_PER_REAL_DAY));
 #endif
-    SPRINTF(buf, "Char ran up charges of %g gold in rent", timegold);
-    log_msg(buf);
+    log_msgf("Char ran up charges of %g gold in rent", timegold);
     SPRINTF(buf, "You ran up charges of %g gold in rent.\n\r", timegold);
     send_to_char(buf, ch);
     GET_GOLD(ch) -= timegold;
@@ -333,7 +333,6 @@ void load_char_objs(struct char_data *ch) {
 void put_obj_in_store(struct obj_data *obj, struct obj_file_u *st) {
   int j;
   struct obj_file_elem *oe;
-  char buf[256];
 
   if (st->number >= MAX_OBJ_SAVE) {
     printf("holy shit, you want to rent more than %d items?!\n", st->number);
@@ -357,10 +356,8 @@ void put_obj_in_store(struct obj_data *obj, struct obj_file_u *st) {
   if (obj->name)
     strcpy(oe->name, obj->name);
   else {
-    SPRINTF(buf, "object %d has no name!",
-            obj_index[obj->item_number].virtual);
-    log_msg(buf);
-
+    log_msgf("object %d has no name!",
+             obj_index[obj->item_number].virtual);
   }
 
   if (obj->short_description)
@@ -510,14 +507,12 @@ void update_obj_file() {
 
       if (read_objs(fl, &st)) {
         if (str_cmp(st.owner, player_table[i].name) != 0) {
-          SPRINTF(buf, "Ack!  Wrong person written into object file! (%s/%s)",
-                  st.owner, player_table[i].name);
-          log_msg(buf);
+          log_msgf("Ack!  Wrong person written into object file! (%s/%s)",
+                   st.owner, player_table[i].name);
           abort();
         }
         else {
-          SPRINTF(buf, "   Processing %s[%ld].", st.owner, i);
-          log_msg(buf);
+          log_msgf("   Processing %s[%ld].", st.owner, i);
           days_passed = ((time(0) - st.last_update) / SECS_PER_REAL_DAY);
           secs_lost = ((time(0) - st.last_update) % SECS_PER_REAL_DAY);
 
@@ -529,8 +524,7 @@ void update_obj_file() {
             ch_st.load_room = NOWHERE;
             st.last_update = time(0) + 3600;    /* one hour grace period */
 
-            SPRINTF(buf, "   Deautorenting %s", st.owner);
-            log_msg(buf);
+            log_msgf("   Deautorenting %s", st.owner);
 
 #if LIMITED_ITEMS
             fprintf(stderr, "Counting limited items\n");
@@ -548,8 +542,7 @@ void update_obj_file() {
 
               if ((st.total_cost * days_passed) > st.gold_left) {
 
-                SPRINTF(buf, "   Dumping %s from object file.", ch_st.name);
-                log_msg(buf);
+                log_msgf("   Dumping %s from object file.", ch_st.name);
 
                 ch_st.points.gold = 0;
                 ch_st.load_room = NOWHERE;
@@ -559,12 +552,9 @@ void update_obj_file() {
 
                 fclose(fl);
                 zero_rent_by_name(ch_st.name);
-
               }
               else {
-
-                SPRINTF(buf, "   Updating %s", st.owner);
-                log_msg(buf);
+                log_msgf("   Updating %s", st.owner);
                 st.gold_left -= (st.total_cost * days_passed);
                 st.last_update = time(0) - secs_lost;
                 fclose(fl);
@@ -579,8 +569,7 @@ void update_obj_file() {
 #if LIMITED_ITEMS
               count_limited_items(&st);
 #endif
-              SPRINTF(buf, "  same day update on %s", st.owner);
-              log_msg(buf);
+              log_msgf("  same day update on %s", st.owner);
               fclose(fl);
             }
           }

--- a/src/security.c
+++ b/src/security.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "utility.h"
 
 void log_msg(char *);
 
@@ -18,8 +19,7 @@ int sec_check(char *arg, char *site) {
   SPRINTF(buf, "security/%s", arg);
 
   if (!(f1 = fopen(buf, "rt"))) {
-    SPRINTF(buf, "Unable to open security file for %s.", arg);
-    log_msg(buf);
+    log_msgf("Unable to open security file for %s.", arg);
     return (-1);
   }
 
@@ -27,8 +27,7 @@ int sec_check(char *arg, char *site) {
   fclose(f1);
 
   if (!*buf2) {
-    SPRINTF(buf, "Security file for %s empty.", arg);
-    log_msg(buf);
+    log_msgf("Security file for %s empty.", arg);
     return (-1);
   }
 
@@ -38,8 +37,8 @@ int sec_check(char *arg, char *site) {
   if (!(strncmp(site, buf2, strlen(buf2)))) {
     return (1);
   }
-  SPRINTF(buf, "Site %s and %s don't match for %s. Booting.", site, buf2, arg);
-  log_msg(buf);
+  log_msgf("Site %s and %s don't match for %s. Booting.",
+           site, buf2, arg);
 
   return (0);
 }

--- a/src/shop.c
+++ b/src/shop.c
@@ -11,6 +11,7 @@
 
 #include "protos.h"
 #include "db.h"
+#include "utility.h"
 
 #define SHOP_FILE "tinyworld.shp"
 #define MAX_TRADE 5
@@ -697,8 +698,7 @@ void boot_the_shops() {
         char *fmt = "***WARNING***: Shop %d has invalid keeper mobile %d";
         char *buf;
         buf = (char *)malloc(strlen(fmt) + 40);
-        SPRINTF(buf, fmt, number_of_shops, keeper);
-        log_msg(buf);
+        log_msgf(fmt, number_of_shops, keeper);
         free(buf);
       }
 

--- a/src/skills.c
+++ b/src/skills.c
@@ -12,6 +12,7 @@
 #include "protos.h"
 #include "skills.h"
 #include "act.move.h"
+#include "utility.h"
 
 extern char *dirs[];
 extern struct char_data *character_list;
@@ -1331,10 +1332,8 @@ void do_palm(struct char_data *ch, char *arg, int cmd) {
               GET_GOLD(ch) += obj_object->obj_flags.value[0];
               if (GET_GOLD(ch) > 100000 &&
                   obj_object->obj_flags.value[0] > 10000) {
-                char buf[MAX_INPUT_LENGTH];
-                SPRINTF(buf, "%s just got %d coins!",
-                        GET_NAME(ch), obj_object->obj_flags.value[0]);
-                log_msg(buf);
+                log_msgf("%s just got %d coins!",
+                         GET_NAME(ch), obj_object->obj_flags.value[0]);
               }
               extract_obj(obj_object);
             }
@@ -1399,10 +1398,8 @@ void do_palm(struct char_data *ch, char *arg, int cmd) {
                     GET_GOLD(ch) += obj_object->obj_flags.value[0];
                     if (GET_GOLD(ch) > 100000 &&
                         obj_object->obj_flags.value[0] > 10000) {
-                      char buf[MAX_INPUT_LENGTH];
-                      SPRINTF(buf, "%s just got %d coins!",
-                              GET_NAME(ch), obj_object->obj_flags.value[0]);
-                      log_msg(buf);
+                      log_msgf("%s just got %d coins!", GET_NAME(ch),
+                               obj_object->obj_flags.value[0]);
                     }
                     extract_obj(obj_object);
                   }
@@ -1630,11 +1627,7 @@ void do_makepotion(struct char_data *ch, char *argument, int UNUSED(cmd)) {
     }
   }
 
-  {
-    char buf[80];
-    SPRINTF(buf, "Min brew level is: %d", max);
-    log_msg(buf);
-  }
+  log_msgf("Min brew level is: %d", max);
 
   extract_obj(potion);
 

--- a/src/spec_assign.c
+++ b/src/spec_assign.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 #if HASH
 extern struct hash_header room_db;
@@ -1011,14 +1012,12 @@ void assign_mobiles() {
   };
 
   int i, rnum;
-  char buf[MAX_STRING_LENGTH];
 
   for (i = 0; specials[i].vnum >= 0; i++) {
     rnum = real_mobile(specials[i].vnum);
     if (rnum < 0) {
-      SPRINTF(buf, "mobile_assign: Mobile %d not found in database.",
-              specials[i].vnum);
-      log_msg(buf);
+      log_msgf("mobile_assign: Mobile %d not found in database.",
+               specials[i].vnum);
     }
     else {
       mob_index[rnum].func = specials[i].proc;
@@ -1065,8 +1064,7 @@ void assign_objects() {
         "***WARNING***: assigning special proc to non-existent object %d";
       char *buf;
       buf = (char *)malloc(strlen(fmt) + 20);
-      SPRINTF(buf, fmt, obj_procs[i].virtual_obj_num);
-      log_msg(buf);
+      log_msgf(fmt, obj_procs[i].virtual_obj_num);
       free(buf);
     }
     i++;
@@ -1110,13 +1108,11 @@ void assign_rooms() {
   };
   int i;
   struct room_data *rp;
-  char buf[80];
 
   for (i = 0; specials[i].vnum >= 0; i++) {
     rp = real_roomp(specials[i].vnum);
     if (rp == NULL) {
-      SPRINTF(buf, "assign_rooms: room %d unknown", specials[i].vnum);
-      log_msg(buf);
+      log_msgf("assign_rooms: room %d unknown", specials[i].vnum);
     }
     else
       rp->funct = specials[i].proc;

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -15,6 +15,7 @@
 #include "db.h"
 #include "act.wizard.h"
 #include "act.move.h"
+#include "utility.h"
 
 #define INQ_SHOUT 1
 #define INQ_LOOSE 0
@@ -274,9 +275,8 @@ int guildmaster(struct char_data *ch, int cmd, char *arg,
         }
         return (TRUE);
       default:
-        SPRINTF(buf, "Strangeness in guildmaster, class %d passed in by %s.",
-                class, GET_NAME(ch));
-        log_msg(buf);
+        log_msgf("Strangeness in guildmaster, class %d passed in by %s.",
+                 class, GET_NAME(ch));
         send_to_char(" 'Ack! I feel faint!'\n\r", ch);
         return (TRUE);
       }
@@ -318,8 +318,7 @@ int guildmaster(struct char_data *ch, int cmd, char *arg,
         }
         return (TRUE);
       default:
-        SPRINTF(buf, "Strangeness in guildmaster for class %d.\n\r", class);
-        log_msg(buf);
+        log_msgf("Strangeness in guildmaster for class %d.\n\r", class);
         send_to_char("Ack, I feel faint!\n\r", ch);
       }                         /* switch */
       return (TRUE);
@@ -4847,7 +4846,6 @@ int tyrannosaurus_swallower(struct char_data *ch, int cmd, char *UNUSED(arg),
   struct char_data *targ;
   struct room_data *rp;
   int i;
-  char buf[256];
 
   extern char DestroyedItems;
 
@@ -4897,8 +4895,7 @@ int tyrannosaurus_swallower(struct char_data *ch, int cmd, char *UNUSED(arg),
            kill target:
          */
         GET_HIT(targ) = 0;
-        SPRINTF(buf, "%s killed by being swallowed whole", GET_NAME(targ));
-        log_msg(buf);
+        log_msgf("%s killed by being swallowed whole", GET_NAME(targ));
         die(targ);
         /*
            all stuff to monster:  this one is tricky.  assume that corpse is
@@ -5634,7 +5631,6 @@ int coldcaster(struct char_data *ch, int cmd, char *UNUSED(arg),
 int trapper(struct char_data *ch, int cmd, char *UNUSED(arg),
             struct char_data *UNUSED(mob), int UNUSED(type)) {
   struct char_data *tch;
-  char buf[256];
 
   if (cmd || !AWAKE(ch))
     return (FALSE);
@@ -5676,9 +5672,8 @@ int trapper(struct char_data *ch, int cmd, char *UNUSED(arg),
       act("$n has suffocated inside $N!",
           FALSE, ch->specials.fighting, 0, ch, TO_ROOM);
       act("$n is dead!", FALSE, ch->specials.fighting, 0, ch, TO_ROOM);
-      SPRINTF(buf, "%s has suffocated to death.",
-              GET_NAME(ch->specials.fighting));
-      log_msg(buf);
+      log_msgf("%s has suffocated to death.",
+               GET_NAME(ch->specials.fighting));
       die(ch->specials.fighting);
       ch->specials.fighting = 0x0;
       return (TRUE);

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -14,6 +14,7 @@
 #include "act.off.h"
 #include "act.wizard.h"
 #include "act.move.h"
+#include "utility.h"
 
 /*   external vars  */
 
@@ -1166,9 +1167,8 @@ int teacher(struct char_data *ch, int cmd, char *arg,
   case TAUGHT_BY_ETTIN:
     break;
   default:
-    SPRINTF(buf, "teacher() attempted to be called with %d(mob#) as teacher.",
-            teacher);
-    log_msg(buf);
+    log_msgf("teacher() attempted to be called with %d(mob#) as teacher.",
+             teacher);
     return (FALSE);
     break;
   }
@@ -2631,7 +2631,6 @@ struct breather breath_monsters[] = {
 
 int breath_weapon_mob(struct char_data *ch, int cmd, char *UNUSED(arg),
                       struct char_data *UNUSED(mob), int UNUSED(type)) {
-  char buf[MAX_STRING_LENGTH];
   struct breather *scan;
   int count;
 
@@ -2645,17 +2644,15 @@ int breath_weapon_mob(struct char_data *ch, int cmd, char *UNUSED(arg),
          scan->vnum >= 0 && scan->vnum != mob_index[ch->nr].virtual; scan++);
 
     if (scan->vnum < 0) {
-      SPRINTF(buf, "monster %s tries to breath, but isn't listed.",
-              ch->player.short_descr);
-      log_msg(buf);
+      log_msgf("monster %s tries to breath, but isn't listed.",
+               ch->player.short_descr);
       return FALSE;
     }
 
     for (count = 0; scan->breaths[count]; count++);
 
     if (count < 1) {
-      SPRINTF(buf, "monster %s has no breath weapons", ch->player.short_descr);
-      log_msg(buf);
+      log_msgf("monster %s has no breath weapons", ch->player.short_descr);
       return FALSE;
     }
 

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 /* because I don't want to recompile */
 
@@ -1976,7 +1977,6 @@ void check_decharm(struct char_data *ch) {
 int check_falling(struct char_data *ch) {
   struct room_data *rp, *targ;
   int done, count, saved;
-  char buf[256];
 
   if (IS_AFFECTED(ch, AFF_FLYING))
     return (FALSE);
@@ -2029,8 +2029,7 @@ int check_falling(struct char_data *ch) {
 
         if (!IS_IMMORTAL(ch)) {
           GET_HIT(ch) = 0;
-          SPRINTF(buf, "%s has fallen to death", GET_NAME(ch));
-          log_msg(buf);
+          log_msgf("%s has fallen to death", GET_NAME(ch));
           if (!ch->desc)
             GET_GOLD(ch) = 0;
           die(ch);
@@ -2100,8 +2099,7 @@ int check_falling(struct char_data *ch) {
 
         if (!IS_IMMORTAL(ch)) {
           GET_HIT(ch) = 0;
-          SPRINTF(buf, "%s has fallen to death", GET_NAME(ch));
-          log_msg(buf);
+          log_msgf("%s has fallen to death", GET_NAME(ch));
           if (!ch->desc)
             GET_GOLD(ch) = 0;
           die(ch);
@@ -2144,7 +2142,6 @@ int check_falling(struct char_data *ch) {
 
 void check_drowning(struct char_data *ch) {
   struct room_data *rp;
-  char buf[256];
 
   if (IS_AFFECTED(ch, AFF_WATERBREATH))
     return;
@@ -2163,8 +2160,7 @@ void check_drowning(struct char_data *ch) {
     GET_MOVE(ch) -= number(10, 50);
     update_pos(ch);
     if (GET_HIT(ch) < -10) {
-      SPRINTF(buf, "%s killed by drowning", GET_NAME(ch));
-      log_msg(buf);
+      log_msgf("%s killed by drowning", GET_NAME(ch));
       if (!ch->desc)
         GET_GOLD(ch) = 0;
       die(ch);

--- a/src/spells2.c
+++ b/src/spells2.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 /* Global data */
 
@@ -1028,8 +1029,6 @@ void cast_shield(byte level, struct char_data *ch, char *UNUSED(arg),
 
 void cast_curse(byte level, struct char_data *ch, char *UNUSED(arg), int type,
                 struct char_data *tar_ch, struct obj_data *tar_obj) {
-  char buf[255];
-
   switch (type) {
   case SPELL_TYPE_SPELL:
     if (tar_obj)                /* It is an object */
@@ -1066,8 +1065,7 @@ void cast_curse(byte level, struct char_data *ch, char *UNUSED(arg), int type,
         spell_curse(level, ch, tar_ch, 0);
     break;
   default:
-    SPRINTF(buf, "Serious screw up in curse! Char = %s.", ch->player.name);
-    log_msg(buf);
+    log_msgf("Serious screw up in curse! Char = %s.", ch->player.name);
     break;
   }
 }
@@ -1883,11 +1881,9 @@ void cast_dragon_breath(byte level, struct char_data *ch, char *UNUSED(arg),
        scan->vnum && scan->vnum != obj_index[potion->item_number].virtual;
        scan++);
   if (scan->vnum == 0) {
-    char buf[MAX_STRING_LENGTH];
     send_to_char("Hey, this potion isn't in my list!\n\r", ch);
-    SPRINTF(buf, "unlisted breath potion %s %d", potion->short_description,
-            obj_index[potion->item_number].virtual);
-    log_msg(buf);
+    log_msgf("unlisted breath potion %s %d", potion->short_description,
+             obj_index[potion->item_number].virtual);
     return;
   }
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -674,11 +674,9 @@ int determine_exp(struct char_data *mob, int exp_flags) {
   int base;
   int phit;
   int sab;
-  char buf[200];
 
   if (exp_flags > 100) {
-    SPRINTF(buf, "Exp flags on %s are > 100 (%d)", GET_NAME(mob), exp_flags);
-    log_msg(buf);
+    log_msgf("Exp flags on %s are > 100 (%d)", GET_NAME(mob), exp_flags);
   }
 
 /* 


### PR DESCRIPTION
Convert a bunch of calls to `sprintf`/`log_msg` to just `log_msgf`. It's less error prone, as evidenced by some of the bugs I found going through this.
