### PR TITLE
Have `make dist` include everything needed.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-AC_INIT([dmserver], [0.1.0], [], [], [https://github.com/jonm/SillyMUD])
+AC_INIT([sillymud], [0.1.0], [], [], [https://github.com/jonm/SillyMUD])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -3,3 +3,5 @@ sillydatadir = $(localstatedir)/sillymud
 sillydata_DATA = Scripts.dat actions credits help help_table info login \
   messages motd news poses tinyworld.mob tinyworld.shp tinyworld.wld \
   tinyworld.zon util wizmotd tinyworld.obj
+EXTRA_DIST = $(sillydata_DATA)
+

--- a/lib/security/Makefile.am
+++ b/lib/security/Makefile.am
@@ -2,3 +2,5 @@ sillysecuritydir = $(localstatedir)/sillymud/security
 sillysecurity_DATA = Agressiva Conner Dm Excavator Felix Fiona Gambreezzi \
   Haplo Loki Mystic Nostromo README Ripper Shark Steppenwolf Stranger \
   Sunsor Xenakis sample
+EXTRA_DIST = $(sillysecurity_DATA)
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,11 @@ common_sources = comm.c act.comm.c act.info.c act.move.c act.obj1.c \
 	reception.c constants.c spec_procs.c signals.c board.c magic.c \
 	magic2.c skills.c Opinion.c Trap.c magicutils.c multiclass.c hash.c \
 	Sound.c Heap.c spec_procs2.c magic3.c security.c spec_procs3.c \
-        create.c parser.c intrinsics.c
+        create.c parser.c intrinsics.c \
+	act.move.h act.off.h act.wizard.h area.h comm.h db.h debug.h \
+	handler.h hash.h heap.h interpreter.h limits.h memory.h parser.h \
+	poly.h protos.h race.h reception.h script.h skills.h spells.h \
+	structs.h trap.h utility.h utils.h vt100c.h wizlist.h
 sillymud_SOURCES = $(common_sources) main.c
 
 # unit tests


### PR DESCRIPTION
Previously, the distribution tarball was missing the data files
in `lib/` and `lib/security`, as well as the `*.h` in `src/`.
