### PR TITLE
Remove duplicate call to `fclose`

### DIFF
--- a/src/reception.c
+++ b/src/reception.c
@@ -256,7 +256,6 @@ void load_char_objs(struct char_data *ch) {
 
   if (!read_objs(fl, &st)) {
     log_msg("No objects found");
-    fclose(fl);
     return;
   }
 


### PR DESCRIPTION
In the case where `read_objs()` returns `FALSE`, the `FILE *fl`
has already had `fclose` called on it by `read_objs`, so this
is a duplicate call. This was causing a crash when run where
the process did not have proper permissions to the library files.
