### PR TITLE
Syslog

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -368,3 +368,10 @@ operates.
 
 `configure' also accepts some other, not widely useful, options.  Run
 `configure --help' for more details.
+
+
+Logging
+=======
+
+The game will log to syslog when avaliable with the program name 'silly'. You
+can filter based on this if you like.

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -3427,7 +3427,7 @@ void create_one_room(int loc_nr) {
          rp->number > zone_table[zone].top && zone <= top_of_zone_table;
          zone++);
     if (zone > top_of_zone_table) {
-      fprintf(stderr, "Room %d is outside of any zone.\n", rp->number);
+      log_msgf("Room %d is outside of any zone.\n", rp->number);
       zone--;
     }
     rp->zone = zone;

--- a/src/comm.c
+++ b/src/comm.c
@@ -621,7 +621,7 @@ int get_from_q(struct txt_q *queue, char *dest) {
     return (0);
 
   if (!dest) {
-    log_wiz("Sending message to null destination.", 5);
+    log_lev_msgf(LOG_CRIT, "Sending message to null destination.");
     return (0);
   }
 
@@ -784,7 +784,6 @@ int new_descriptor(int s) {
   struct sockaddr peer;
 #endif
   struct sockaddr_in sock;
-  char buf[200];
 
   if ((desc = new_connection(s)) < 0)
     return (-1);
@@ -820,15 +819,13 @@ int new_descriptor(int s) {
 #ifndef sun
     if ((long)strncpy(newd->host, inet_ntoa(sock.sin_addr), 49) > 0) {
       *(newd->host + 49) = '\0';
-      SPRINTF(buf, "New connection from addr %s: %d: %d", newd->host, desc,
-              maxdesc);
-      log_wiz(buf, 3);
+      log_lev_msgf(LOG_WARNING, "New connection from addr %s: %d: %d",
+                   newd->host, desc, maxdesc);
     }
 #else
     strcpy(newd->host, (char *)inet_ntoa(&sock.sin_addr));
-    SPRINTF(buf, "New connection from addr %s: %d: %d", newd->host, desc,
-            maxdesc);
-    log_wiz(buf, 3);
+    log_lev_msgf(LOG_WARNING, "New connection from addr %s: %d: %d",
+                   newd->host, desc, maxdesc);
 #endif
   }
 

--- a/src/comm.c
+++ b/src/comm.c
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <sys/resource.h>
 #include <unistd.h>
+#include <syslog.h>
 
 #include "structs.h"
 #include "protos.h"
@@ -105,7 +106,7 @@ int real_main(int argc, char **argv) {
   int res;
 #endif
 
-
+  openlog("silly", LOG_CONS|LOG_PID, LOG_USER);
 
   port = DFLT_PORT;
   dir = DEFAULT_LIBDIR;

--- a/src/comm.c
+++ b/src/comm.c
@@ -621,7 +621,7 @@ int get_from_q(struct txt_q *queue, char *dest) {
     return (0);
 
   if (!dest) {
-    log_sev("Sending message to null destination.", 5);
+    log_wiz("Sending message to null destination.", 5);
     return (0);
   }
 
@@ -822,13 +822,13 @@ int new_descriptor(int s) {
       *(newd->host + 49) = '\0';
       SPRINTF(buf, "New connection from addr %s: %d: %d", newd->host, desc,
               maxdesc);
-      log_sev(buf, 3);
+      log_wiz(buf, 3);
     }
 #else
     strcpy(newd->host, (char *)inet_ntoa(&sock.sin_addr));
     SPRINTF(buf, "New connection from addr %s: %d: %d", newd->host, desc,
             maxdesc);
-    log_sev(buf, 3);
+    log_wiz(buf, 3);
 #endif
   }
 

--- a/src/convert.c
+++ b/src/convert.c
@@ -159,14 +159,14 @@ main(int argc, char *argv[]) {
         fucked++;
         ok = FALSE;
       }
-    fprintf(stderr, "[%-4d] %s\n", i, pt2.name);
+    log_msgf("[%-4d] %s\n", i, pt2.name);
     if (!feof(f) && ok) {
       fwrite(&pt1, sizeof(struct char_file_u2), 1, f2);
       fwrite(&insert, sizeof(struct bart), 1, f2);
       fwrite(&pt2, sizeof(struct char_file_u3), 1, f2);
     }
     if (!(i % 100))
-      fprintf(stderr, ".");
+      log_msgf(".");
   }
 
   fclose(f);

--- a/src/create.c
+++ b/src/create.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 #define MAIN_MENU           0
 #define CHANGE_NAME         1

--- a/src/db.c
+++ b/src/db.c
@@ -2068,7 +2068,7 @@ void reset_zone(int zone) {
                     "eq error - zone %d, cmd %d, item %d, mob %d, loc %d\n",
                     zone, cmd_no, obj_index[ZCMD.arg1].virtual,
                     mob_index[mob->nr].virtual, ZCMD.arg3);
-            log_sev(buf, 6);
+            log_wiz(buf, 6);
           }
           last_cmd = 1;
         }
@@ -3574,7 +3574,7 @@ void read_text_zone(FILE * fl) {
             SPRINTF(buf, "eq error - zone %d, cmd %d, item %d, mob %d, loc %d",
                     zone, 1, obj_index[i].virtual,
                     mob_index[mob->nr].virtual, k);
-            log_sev(buf, 6);
+            log_wiz(buf, 6);
           }
           last_cmd = 1;
         }
@@ -3640,12 +3640,12 @@ int verify_mob(struct char_data *ch) {
 
   if (ch->specials.damnodice < 0) {
     SPRINTF(buf, "%s's number of damage dice is negative\n", ch->player.name);
-    log_sev(buf, 6);
+    log_wiz(buf, 6);
   }
 
   if (ch->specials.damsizedice < 0) {
     SPRINTF(buf, "%s's size of damage dice is negative\n", ch->player.name);
-    log_sev(buf, 6);
+    log_wiz(buf, 6);
   }
   return (1);
 }

--- a/src/db.c
+++ b/src/db.c
@@ -1873,7 +1873,6 @@ void zone_update() {
 /* execute the reset command table of a given zone */
 void reset_zone(int zone) {
   int cmd_no, last_cmd = 1;
-  char buf[256];
   struct char_data *mob;
   struct char_data *master;
   struct obj_data *obj, *obj_to;
@@ -2064,11 +2063,10 @@ void reset_zone(int zone) {
             equip_char(mob, obj, ZCMD.arg3);
           }
           else {
-            SPRINTF(buf,
-                    "eq error - zone %d, cmd %d, item %d, mob %d, loc %d\n",
-                    zone, cmd_no, obj_index[ZCMD.arg1].virtual,
-                    mob_index[mob->nr].virtual, ZCMD.arg3);
-            log_wiz(buf, 6);
+            log_lev_msgf(LOG_ALERT,
+                         "eq error - zone %d, cmd %d, item %d, mob %d, loc %d\n",
+                         zone, cmd_no, obj_index[ZCMD.arg1].virtual,
+                         mob_index[mob->nr].virtual, ZCMD.arg3);
           }
           last_cmd = 1;
         }
@@ -3571,10 +3569,10 @@ void read_text_zone(FILE * fl) {
             equip_char(mob, obj, k);
           }
           else {
-            SPRINTF(buf, "eq error - zone %d, cmd %d, item %d, mob %d, loc %d",
-                    zone, 1, obj_index[i].virtual,
-                    mob_index[mob->nr].virtual, k);
-            log_wiz(buf, 6);
+            log_lev_msgf(LOG_ALERT,
+                         "eq error - zone %d, cmd %d, item %d, mob %d, loc %d",
+                         zone, 1, obj_index[i].virtual,
+                         mob_index[mob->nr].virtual, k);
           }
           last_cmd = 1;
         }
@@ -3635,17 +3633,17 @@ void boot_figurines() {
 }
 
 int verify_mob(struct char_data *ch) {
-  char buf[256];
   /* check to see that the mob falls within certain parameters */
 
   if (ch->specials.damnodice < 0) {
-    SPRINTF(buf, "%s's number of damage dice is negative\n", ch->player.name);
-    log_wiz(buf, 6);
+    log_lev_msgf(LOG_ALERT,
+                 "%s's number of damage dice is negative\n",
+                 ch->player.name);
   }
 
   if (ch->specials.damsizedice < 0) {
-    SPRINTF(buf, "%s's size of damage dice is negative\n", ch->player.name);
-    log_wiz(buf, 6);
+    log_lev_msgf(LOG_ALERT, "%s's size of damage dice is negative\n",
+                 ch->player.name);
   }
   return (1);
 }

--- a/src/db.c
+++ b/src/db.c
@@ -200,19 +200,19 @@ void boot_db() {
     s = zone_table[i].name;
     d = (i ? (zone_table[i - 1].top + 1) : 0);
     e = zone_table[i].top;
-    fprintf(stderr, "Performing boot-time init of %s (rooms %d-%d).\n",
-            s, d, e);
+    log_msgf("Performing boot-time init of %s (rooms %d-%d)",
+             s, d, e);
     zone_table[i].start = 0;
 
 
     if (i == 0) {
-      fprintf(stderr, "Performing boot-time reload of static mobs\n");
+      log_msgf("Performing boot-time reload of static mobs");
       reset_zone(0);
 
     }
 
     if (i == 1) {
-      fprintf(stderr, "Automatic initialization of  %s\n", s);
+      log_msgf("Automatic initialization of  %s\n", s);
       reset_zone(1);
     }
   }
@@ -677,7 +677,7 @@ struct index_data *generate_indices(FILE * fl, int *top) {
       }
     }
     else {
-      fprintf(stderr, "generate indices");
+      log_msgf("generate indices");
       assert(0);
     }
   }
@@ -755,7 +755,7 @@ void load_one_room(FILE * fl, struct room_data *rp) {
          rp->number > zone_table[zone].top && zone <= top_of_zone_table;
          zone++);
     if (zone > top_of_zone_table) {
-      fprintf(stderr, "Room %d is outside of any zone.\n", rp->number);
+      log_msgf("Room %d is outside of any zone.\n", rp->number);
       assert(0);
     }
     rp->zone = zone;
@@ -828,13 +828,13 @@ void load_one_room(FILE * fl, struct room_data *rp) {
       if (new_descr->keyword && *new_descr->keyword)
         bc += strlen(new_descr->keyword);
       else
-        fprintf(stderr, "No keyword in room %d\n", rp->number);
+        log_msgf("No keyword in room %d\n", rp->number);
 
       new_descr->description = fread_string(fl);
       if (new_descr->description && *new_descr->description)
         bc += strlen(new_descr->description);
       else
-        fprintf(stderr, "No desc in room %d\n", rp->number);
+        log_msgf("No desc in room %d\n", rp->number);
 
       new_descr->next = rp->ex_description;
       rp->ex_description = new_descr;
@@ -843,7 +843,7 @@ void load_one_room(FILE * fl, struct room_data *rp) {
 
 #if BYTE_COUNT
       if (bc >= 1000)
-        fprintf(stderr, "Byte count for this room[%d]: %d\n", rp->number, bc);
+        log_msgf("Byte count for this room[%d]: %d\n", rp->number, bc);
 #endif
       total_bc += bc;
       room_count++;
@@ -886,7 +886,7 @@ void boot_world() {
     if (rp)
       bzero(rp, sizeof(*rp));
     else {
-      fprintf(stderr, "Error, room %d not in database!(%d)\n",
+      log_msgf("Error, room %d not in database!(%d)\n",
               virtual_nr, last);
       assert(0);
     }
@@ -1635,7 +1635,7 @@ struct char_data *read_mobile(int nr, int type) {
   mob_index[nr].number++;
 
 #if BYTE_COUNT
-  fprintf(stderr, "Mobile [%d]: byte count: %d\n", mob_index[nr].virtual, bc);
+  log_msgf("Mobile [%d]: byte count: %d\n", mob_index[nr].virtual, bc);
 #endif
 
   total_mbc += bc;
@@ -1785,7 +1785,7 @@ struct obj_data *read_object(int nr, int type) {
 
   obj_count++;
 #if BYTE_COUNT
-  fprintf(stderr, "Object [%d] uses %d bytes\n", obj_index[nr].virtual, bc);
+  log_msgf("Object [%d] uses %d bytes\n", obj_index[nr].virtual, bc);
 #endif
   total_obc += bc;
   return (obj);
@@ -3251,9 +3251,9 @@ void init_scripts() {
             (struct foo_data *)realloc(script_data[top_of_scripts].script,
                                        sizeof(struct foo_data) * (count + 1));
         }
-        fprintf(stderr, "top_of_scripts %d\n", top_of_scripts);
-        fprintf(stderr, "count %d\n", count);
-        fprintf(stderr, "buf2: %s\n", buf2);
+        log_msgf("top_of_scripts %d\n", top_of_scripts);
+        log_msgf("count %d\n", count);
+        log_msgf("buf2: %s\n", buf2);
         script_data[top_of_scripts].script[count].line =
           (char *)malloc(sizeof(char) * (strlen(buf) + 1));
 

--- a/src/fight.c
+++ b/src/fight.c
@@ -1275,7 +1275,7 @@ int damage_epilog(struct char_data *ch, struct char_data *victim) {
                 GET_NAME(victim),
                 (IS_NPC(ch) ? ch->player.short_descr : GET_NAME(ch)));
       }
-      log_sev(buf, 6);
+      log_wiz(buf, 6);
     }
     die(victim);
     /*

--- a/src/fight.c
+++ b/src/fight.c
@@ -1275,7 +1275,7 @@ int damage_epilog(struct char_data *ch, struct char_data *victim) {
                 GET_NAME(victim),
                 (IS_NPC(ch) ? ch->player.short_descr : GET_NAME(ch)));
       }
-      log_wiz(buf, 6);
+      log_lev_msgf(LOG_ALERT, "%s", buf);
     }
     die(victim);
     /*

--- a/src/handler.c
+++ b/src/handler.c
@@ -381,10 +381,10 @@ void affect_modify(struct char_data *ch, byte loc, long mod, long bitv,
   case APPLY_HASTE:
     if (mod > 0) {
       if (WizLock)
-        fprintf(stderr, "current mult = %f\n", ch->mult_att);
+        log_msgf("current mult = %f\n", ch->mult_att);
       ch->mult_att = ch->mult_att * 2.0;
       if (WizLock)
-        fprintf(stderr, "new mult = %f\n", ch->mult_att);
+        log_msgf("new mult = %f\n", ch->mult_att);
     }
     else if (mod < 0) {
       ch->mult_att = ch->mult_att / 2.0;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -1699,7 +1699,7 @@ void nanny(struct descriptor_data *d, char *arg) {
       }
       else if (d->character->generic >= NEWBIE_REQUEST) {
         SPRINTF(buf, "%s [%s] new player.", GET_NAME(d->character), d->host);
-        log_sev(buf, 7);
+        log_wiz(buf, 7);
         if (!strncmp(d->host, "128.197.152", 11))
           d->character->generic = 1;
         /* I decided to give them another chance.  -Steppenwolf  */
@@ -1712,8 +1712,8 @@ void nanny(struct descriptor_data *d, char *arg) {
           if (top_of_p_table > 0) {
             SPRINTF(buf, "type Auth[orize] %s to allow into game.",
                     GET_NAME(d->character));
-            log_sev(buf, 6);
-            log_sev("type 'Help Authorize' for other commands", 2);
+            log_wiz(buf, 6);
+            log_wiz("type 'Help Authorize' for other commands", 2);
           }
           else {
             log_msg("Initial character.  Authorized Automatically");

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -1698,8 +1698,8 @@ void nanny(struct descriptor_data *d, char *arg) {
         STATE(d) = CON_RMOTD;
       }
       else if (d->character->generic >= NEWBIE_REQUEST) {
-        SPRINTF(buf, "%s [%s] new player.", GET_NAME(d->character), d->host);
-        log_wiz(buf, 7);
+        log_lev_msgf(LOG_EMERG, "%s [%s] new player.",
+                     GET_NAME(d->character), d->host);
         if (!strncmp(d->host, "128.197.152", 11))
           d->character->generic = 1;
         /* I decided to give them another chance.  -Steppenwolf  */
@@ -1710,10 +1710,11 @@ void nanny(struct descriptor_data *d, char *arg) {
         }
         else {
           if (top_of_p_table > 0) {
-            SPRINTF(buf, "type Auth[orize] %s to allow into game.",
-                    GET_NAME(d->character));
-            log_wiz(buf, 6);
-            log_wiz("type 'Help Authorize' for other commands", 2);
+            log_lev_msgf(LOG_ALERT,
+                         "type Auth[orize] %s to allow into game.",
+                         GET_NAME(d->character));
+            log_lev_msgf(LOG_NOTICE, "%s",
+                         "type 'Help Authorize' for other commands");
           }
           else {
             log_msg("Initial character.  Authorized Automatically");

--- a/src/limits.c
+++ b/src/limits.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 #include "act.other.h"
 
 struct room_data *real_roomp(int);

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -65,7 +65,6 @@ void mobile_wander(struct char_data *ch) {
   int door, or;
   struct room_direction_data *exitp;
   struct room_data *rp;
-  char buf[100];
   extern int rev_dir[];
 
   if (GET_POS(ch) != POSITION_STANDING)
@@ -111,8 +110,8 @@ void mobile_wander(struct char_data *ch) {
         go_direction(ch, door);
         if (ch->in_room == 0) {
           if (or != 0) {
-            SPRINTF(buf, "%s just entered void from %d", GET_NAME(ch), or);
-            log_wiz(buf, 5);
+            log_lev_msgf(LOG_CRIT, "%s just entered void from %d",
+                         GET_NAME(ch), or);
           }
         }
         return;

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -112,7 +112,7 @@ void mobile_wander(struct char_data *ch) {
         if (ch->in_room == 0) {
           if (or != 0) {
             SPRINTF(buf, "%s just entered void from %d", GET_NAME(ch), or);
-            log_sev(buf, 5);
+            log_wiz(buf, 5);
           }
         }
         return;

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -817,8 +817,8 @@ void sgoto(char *arg, struct char_data *ch) {
       arg++;
       p = strtok(arg, " ");
       if ((mob = get_char_vis(ch, p)) == NULL) {
-        fprintf(stderr, "%s couldn't find mob by name %s\n",
-                script_data[ch->script].filename, p);
+        log_msgf("%s couldn't find mob by name %s\n",
+                 script_data[ch->script].filename, p);
         ch->commandp++;
         return;
       }

--- a/src/modify.c
+++ b/src/modify.c
@@ -12,6 +12,7 @@
 #include <time.h>
 
 #include "protos.h"
+#include "utility.h"
 
 #define REBOOT_AT    10         /* 0-23, time of optional reboot if -e lib/reboot */
 

--- a/src/protos.h
+++ b/src/protos.h
@@ -1423,7 +1423,6 @@ void cast_resist_blunt(byte level, struct char_data *ch, char *arg, int type,
 
 
 /* From utility.c */
-void log_msg(char *buf);
 int char_array_size(char *thingie[]);
 int ego_blade_save(struct char_data *ch);
 int MIN(int a, int b);

--- a/src/protos.h
+++ b/src/protos.h
@@ -1446,7 +1446,6 @@ int dice(int number, int size);
 int scan_number(char *text, int *rval);
 int str_cmp(char *arg1, char *arg2);
 int strn_cmp(char *arg1, char *arg2, int n);
-void log_wiz(char *str, int sev);
 void slog(char *str);
 void sprintbit(unsigned long vektor, char *names[], char *result);
 void sprinttype(int type, char *names[], char *result);

--- a/src/protos.h
+++ b/src/protos.h
@@ -1447,7 +1447,7 @@ int dice(int number, int size);
 int scan_number(char *text, int *rval);
 int str_cmp(char *arg1, char *arg2);
 int strn_cmp(char *arg1, char *arg2, int n);
-void log_sev(char *str, int sev);
+void log_wiz(char *str, int sev);
 void slog(char *str);
 void sprintbit(unsigned long vektor, char *names[], char *result);
 void sprinttype(int type, char *names[], char *result);

--- a/src/reception.c
+++ b/src/reception.c
@@ -528,9 +528,9 @@ void update_obj_file() {
             log_msgf("   Deautorenting %s", st.owner);
 
 #if LIMITED_ITEMS
-            fprintf(stderr, "Counting limited items\n");
+            log_msgf("Counting limited items\n");
             count_limited_items(&st);
-            fprintf(stderr, "Done\n");
+            log_msgf("Done\n");
 #endif
             fseek(char_file, (long)(player_table[i].nr *
                                     sizeof(struct char_file_u)), 0);

--- a/src/security.c
+++ b/src/security.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include "utility.h"
 
-void log_msg(char *);
 
 int sec_check(char *arg, char *site) {
   char buf[255], buf2[255];

--- a/src/signals.c
+++ b/src/signals.c
@@ -11,6 +11,7 @@
 #include <sys/time.h>
 
 #include "protos.h"
+#include "utility.h"
 
 void checkpointing(int);
 void shutdown_request(int);

--- a/src/spells1.c
+++ b/src/spells1.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 
 #include "protos.h"
+#include "utility.h"
 
 
 /* Global data */

--- a/src/utility.c
+++ b/src/utility.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
+#include <syslog.h>
 
 #include "protos.h"
 #include "utility.h"
@@ -21,6 +22,7 @@
 #include "act.move.h"
 
 void log_msg(char *s) {
+  syslog(LOG_INFO, "%s", s);
   log_sev(s, 1);
 }                               /*thought this was a prototype - heheh */
 
@@ -28,6 +30,7 @@ void log_msgf(const char *fmt, ...) {
   char buf[256];
   va_list args;
   va_start(args, fmt);
+  syslog(LOG_INFO, fmt, args);
   vsnprintf(buf, sizeof(buf), fmt, args);
   log_sev(buf, 1);
   va_end(args);
@@ -342,17 +345,8 @@ int strn_cmp(char *arg1, char *arg2, int n) {
 
 /* writes a string to the log */
 void log_sev(char *str, int sev) {
-  long ct;
-  char *tmstr;
   static char buf[500];
   struct descriptor_data *i;
-
-
-  ct = time(0);
-  tmstr = asctime(localtime(&ct));
-  *(tmstr + strlen(tmstr) - 1) = '\0';
-  fprintf(stderr, "%s :: %s\n", tmstr, str);
-
 
   if (str)
     SPRINTF(buf, "/* %s */\n\r", str);

--- a/src/utility.c
+++ b/src/utility.c
@@ -22,20 +22,27 @@
 #include "act.move.h"
 
 
-void log_lev_msgf(int level, const char *fmt, ...) {
+void vlog_lev_msgf(int level, const char *fmt, va_list args) {
   char buf[256];
+  va_list nargs;
+  va_copy(nargs, args);
+  vsyslog(level, fmt, args);
+  vsnprintf(buf, sizeof(buf), fmt, nargs);
+  va_end(nargs);
+  log_wiz(buf, level);
+}
+
+void log_lev_msgf(int level, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
-  vsyslog(level, fmt, args);
-  vsnprintf(buf, sizeof(buf), fmt, args);
-  log_wiz(buf, level);
+  vlog_lev_msgf(level, fmt, args);
   va_end(args);
 }
 
 void log_msgf(const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
-  log_lev_msgf(LOG_INFO, fmt, args);
+  vlog_lev_msgf(LOG_INFO, fmt, args);
   va_end(args);
 }
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -30,7 +30,7 @@ void log_msgf(const char *fmt, ...) {
   char buf[256];
   va_list args;
   va_start(args, fmt);
-  syslog(LOG_INFO, fmt, args);
+  vsyslog(LOG_INFO, fmt, args);
   vsnprintf(buf, sizeof(buf), fmt, args);
   log_sev(buf, 1);
   va_end(args);

--- a/src/utility.c
+++ b/src/utility.c
@@ -21,20 +21,28 @@
 #include "act.other.h"
 #include "act.move.h"
 
-void log_msg(char *s) {
-  syslog(LOG_INFO, "%s", s);
-  log_wiz(s, 1);
-}                               /*thought this was a prototype - heheh */
 
-void log_msgf(const char *fmt, ...) {
+void log_lev_msgf(int level, const char *fmt, ...) {
   char buf[256];
   va_list args;
   va_start(args, fmt);
-  vsyslog(LOG_INFO, fmt, args);
+  vsyslog(level, fmt, args);
   vsnprintf(buf, sizeof(buf), fmt, args);
-  log_wiz(buf, 1);
+  log_wiz(buf, level);
   va_end(args);
 }
+
+void log_msgf(const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  log_lev_msgf(LOG_INFO, fmt, args);
+  va_end(args);
+}
+
+void log_msg(const char *s) {
+  log_msgf("%s", s);
+}
+
 
 extern char *article_list[];
 extern struct time_data time_info;

--- a/src/utility.c
+++ b/src/utility.c
@@ -23,7 +23,7 @@
 
 void log_msg(char *s) {
   syslog(LOG_INFO, "%s", s);
-  log_sev(s, 1);
+  log_wiz(s, 1);
 }                               /*thought this was a prototype - heheh */
 
 void log_msgf(const char *fmt, ...) {
@@ -32,7 +32,7 @@ void log_msgf(const char *fmt, ...) {
   va_start(args, fmt);
   vsyslog(LOG_INFO, fmt, args);
   vsnprintf(buf, sizeof(buf), fmt, args);
-  log_sev(buf, 1);
+  log_wiz(buf, 1);
   va_end(args);
 }
 
@@ -343,8 +343,8 @@ int strn_cmp(char *arg1, char *arg2, int n) {
 
 
 
-/* writes a string to the log */
-void log_sev(char *str, int sev) {
+/* writes a string to the logged in wizards */
+void log_wiz(char *str, int sev) {
   static char buf[500];
   struct descriptor_data *i;
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -364,7 +364,7 @@ void slog(char *str) {
   ct = time(0);
   tmstr = asctime(localtime(&ct));
   *(tmstr + strlen(tmstr) - 1) = '\0';
-  fprintf(stderr, "%s :: %s\n", tmstr, str);
+  log_msgf("%s :: %s\n", tmstr, str);
 
 }
 
@@ -2271,7 +2271,7 @@ int mob_count_in_room(struct char_data *list) {
 
 void *mymalloc(long size) {
   if (size < 1) {
-    fprintf(stderr, "attempt to malloc negative memory - %ld\n", size);
+    log_msgf("attempt to malloc negative memory - %ld\n", size);
     assert(0);
   }
   return (malloc(size));

--- a/src/utility.h
+++ b/src/utility.h
@@ -1,8 +1,11 @@
 #ifndef _UTILITY_H
 #define _UTILITY_H
 
+#include <syslog.h>
+
 void log_lev_msgf(int level, const char *fmt, ...);
 void log_msgf(const char *fmt, ...);
 void log_msg(const char *str);
+void log_wiz(char *str, int sev);
 
 #endif /* #ifdef _UTILITY_H */

--- a/src/utility.h
+++ b/src/utility.h
@@ -1,6 +1,8 @@
 #ifndef _UTILITY_H
 #define _UTILITY_H
 
+void log_lev_msgf(int level, const char *fmt, ...);
 void log_msgf(const char *fmt, ...);
+void log_msg(const char *str);
 
 #endif /* #ifdef _UTILITY_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,7 +11,7 @@
 
 #if DEBUG
 
-#define free(obj) fprintf(stderr, "freeing %d\n", sizeof(*obj));\
+#define free(obj) log_msgf("freeing %d\n", sizeof(*obj));\
 		      free(obj)
 
 #endif

--- a/src/weather.c
+++ b/src/weather.c
@@ -412,23 +412,23 @@ void switch_light(byte why) {
 
   switch (why) {
   case MOON_SET:
-    log_sev("setting all rooms to dark", 2);
+    log_wiz("setting all rooms to dark", 2);
     gLightLevel = 0;
     break;
   case SUN_LIGHT:
-    log_sev("setting all rooms to light", 2);
+    log_wiz("setting all rooms to light", 2);
     gLightLevel = 4;
     break;
   case SUN_DARK:
-    log_sev("setting all rooms to dark", 2);
+    log_wiz("setting all rooms to dark", 2);
     gLightLevel = 0;
     break;
   case MOON_RISE:
-    log_sev("setting all non-forest to light", 2);
+    log_wiz("setting all non-forest to light", 2);
     gLightLevel = 1;
     break;
   default:
-    log_sev("Unknown switch on switch_light", 2);
+    log_wiz("Unknown switch on switch_light", 2);
     break;
   }
 

--- a/src/weather.c
+++ b/src/weather.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "protos.h"
+#include "utility.h"
 
 /* uses */
 
@@ -412,23 +413,23 @@ void switch_light(byte why) {
 
   switch (why) {
   case MOON_SET:
-    log_wiz("setting all rooms to dark", 2);
+    log_lev_msgf(LOG_NOTICE, "%s", "setting all rooms to dark");
     gLightLevel = 0;
     break;
   case SUN_LIGHT:
-    log_wiz("setting all rooms to light", 2);
+    log_lev_msgf(LOG_NOTICE, "%s", "setting all rooms to light");
     gLightLevel = 4;
     break;
   case SUN_DARK:
-    log_wiz("setting all rooms to dark", 2);
+    log_lev_msgf(LOG_NOTICE, "%s", "setting all rooms to dark");
     gLightLevel = 0;
     break;
   case MOON_RISE:
-    log_wiz("setting all non-forest to light", 2);
+    log_lev_msgf(LOG_NOTICE, "%s", "setting all non-forest to light");
     gLightLevel = 1;
     break;
   default:
-    log_wiz("Unknown switch on switch_light", 2);
+    log_lev_msgf(LOG_NOTICE, "%s", "Unknown switch on switch_light");
     break;
   }
 


### PR DESCRIPTION
Instead of shoving everything to stderr, uses `syslog` to log if it is running. Right now everything is logged with the `LOG_INFO` severity. We could potentially have different levels in the future and handle them differently.

I added `/etc/rsyslog.d/20-silly.conf` on the server to log all silly messages to `/usr/local/var/sillymud/silly.log`. I don' t know if you have some instance provisioning this should go into.

Fixes #54 
