### PR TITLE
Func protos

### DIFF
--- a/src/Opinion.c
+++ b/src/Opinion.c
@@ -12,12 +12,12 @@
 #include <time.h>
 
 #include "protos.h"
+#include "db.h"
 
 /*
   external stuff
 */
 
-extern struct index_data *mob_index;
 extern struct room_data *world;
 
 void free_hates(struct char_data *ch) {

--- a/src/Sound.c
+++ b/src/Sound.c
@@ -13,7 +13,6 @@
 
 /* extern variables */
 
-extern struct obj_data *object_list;
 extern struct char_data *character_list;
 
 int rec_get_obj_room(struct obj_data *obj) {

--- a/src/act.info.c
+++ b/src/act.info.c
@@ -3453,7 +3453,6 @@ void do_resize(struct char_data *ch, char *arg,
 
 int mob_lev_bonus(struct char_data *ch) {
   int t = 0;
-  extern struct index_data *mob_index;
 
   if (mob_index[ch->nr].func == magic_user)
     t += 5;

--- a/src/act.move.c
+++ b/src/act.move.c
@@ -14,6 +14,7 @@
 #include "act.other.h"
 #include "spec_procs3.h"
 #include "utility.h"
+#include "db.h"
 
 /*   external vars  */
 #if HASH
@@ -23,7 +24,6 @@ extern struct room_data *room_db;
 #endif
 extern struct char_data *character_list;
 extern struct descriptor_data *descriptor_list;
-extern struct index_data *obj_index;
 extern int rev_dir[];
 extern char *dirs[];
 extern int movement_loss[];

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -14,6 +14,7 @@
 #include "act.other.h"
 #include "spec_procs2.h"
 #include "utility.h"
+#include "db.h"
 
 /* extern variables */
 
@@ -1360,7 +1361,6 @@ void do_wimp(struct char_data *ch, char *argument,
 
 
 extern struct breather breath_monsters[];
-extern struct index_data *mob_index;
 void (*bweapons[]) (byte, struct char_data *, char *, int, struct char_data *,
                     struct obj_data *) = {
 cast_geyser, cast_fire_breath, cast_gas_breath, cast_frost_breath,

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -14,6 +14,7 @@
 #include "act.comm.h"
 #include "act.other.h"
 #include "utility.h"
+#include "db.h"
 
 
 /* extern variables */
@@ -23,7 +24,6 @@ extern struct descriptor_data *descriptor_list;
 extern struct dex_skill_type dex_app_skill[];
 extern struct skill_data skill_info[];
 extern struct char_data *character_list;
-extern struct index_data *obj_index;
 extern struct time_info_data time_info;
 
 

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -3126,7 +3126,6 @@ void do_show(struct char_data *ch, char *argument,
              const char * UNUSED(cmd)) {
   int zone;
   char buf[MAX_STRING_LENGTH], zonenum[MAX_INPUT_LENGTH];
-  struct obj_index_data *which_i;
   int bottom, top, topi;
   struct string_block sb;
 
@@ -3181,7 +3180,6 @@ void do_show(struct char_data *ch, char *argument,
   }
   else if (is_abbrev(buf, "mobiles")) {
     topi = top_of_mobt;
-    int objn;
     struct mob_index_data *mi;
 
     only_argument(argument, zonenum);
@@ -3197,21 +3195,20 @@ void do_show(struct char_data *ch, char *argument,
     }
 
     append_to_string_block(&sb, "VNUM  rnum count names\n\r");
-    for (objn = 0; objn <= topi; objn++) {
-      mi = mob_index + objn;
+    for (int mobn = 0; mobn <= topi; mobn++) {
+      mi = mob_index + mobn;
 
       if ((zone >= 0 && (mi->virtual < bottom || mi->virtual > top)) ||
           (zone < 0 && !isname(zonenum, mi->name)))
         continue;               /* optimize later */
 
-      SPRINTF(buf, "%5d %4d %3d  %s\n\r", mi->virtual, objn,
+      SPRINTF(buf, "%5d %4d %3d  %s\n\r", mi->virtual, mobn,
               mi->number, mi->name);
       append_to_string_block(&sb, buf);
     }
   }
   else if (is_abbrev(buf, "objects")) {
     topi = top_of_objt;
-    int objn;
     struct obj_index_data *oi;
 
     only_argument(argument, zonenum);
@@ -3227,7 +3224,7 @@ void do_show(struct char_data *ch, char *argument,
     }
 
     append_to_string_block(&sb, "VNUM  rnum count names\n\r");
-    for (objn = 0; objn <= topi; objn++) {
+    for (int objn = 0; objn <= topi; objn++) {
       oi = obj_index + objn;
 
       if ((zone >= 0 && (oi->virtual < bottom || oi->virtual > top)) ||
@@ -3238,9 +3235,7 @@ void do_show(struct char_data *ch, char *argument,
               oi->number, oi->name);
       append_to_string_block(&sb, buf);
     }
-
-
-  }  
+  }
   else if (is_abbrev(buf, "rooms")) {
 
     only_argument(argument, zonenum);
@@ -3260,14 +3255,11 @@ void do_show(struct char_data *ch, char *argument,
 #else
       room_iterate(room_db, print_private_room, &sb);
 #endif
-
     }
     else if (1 != sscanf(zonenum, "%i", &zone) ||
              zone < 0 || zone > top_of_zone_table) {
       append_to_string_block(&sb,
                              "I need a zone number with this command\n\r");
-
-
     }
     else {
       struct show_room_zone_struct srzs;
@@ -3298,7 +3290,7 @@ void do_show(struct char_data *ch, char *argument,
     struct obj_index_data *oi, *oi2;
     char buf[80];
 
-    which_i = obj_index;
+    struct obj_index_data *which_i = obj_index;
     topi = top_of_objt;
     bot = 0;
 

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -20,6 +20,7 @@
 #include "act.wizard.h"
 #include "act.info.h"
 #include "utility.h"
+#include "db.h"
 
 /*   external vars  */
 
@@ -35,8 +36,6 @@ extern struct descriptor_data *descriptor_list;
 extern struct title_type titles[MAX_CLASS][ABS_MAX_LVL];
 extern struct time_info_data time_info;
 extern struct weather_data weather_info;
-extern struct index_data *mob_index;
-extern struct index_data *obj_index;
 extern int top_of_mobt;
 extern int top_of_objt;
 extern struct int_app_type int_app[26];
@@ -3127,7 +3126,7 @@ void do_show(struct char_data *ch, char *argument,
              const char * UNUSED(cmd)) {
   int zone;
   char buf[MAX_STRING_LENGTH], zonenum[MAX_INPUT_LENGTH];
-  struct index_data *which_i;
+  struct obj_index_data *which_i;
   int bottom, top, topi;
   struct string_block sb;
 
@@ -3185,7 +3184,7 @@ void do_show(struct char_data *ch, char *argument,
            (is_abbrev(buf, "mobiles") &&
             (which_i = mob_index, topi = top_of_mobt))) {
     int objn;
-    struct index_data *oi;
+    struct obj_index_data *oi;
 
     only_argument(argument, zonenum);
     zone = -1;
@@ -3268,7 +3267,7 @@ void do_show(struct char_data *ch, char *argument,
   else if (is_abbrev(buf, "top")) {
 
     int objn, top_ten[10], i, insert, tmp, bot;
-    struct index_data *oi, *oi2;
+    struct obj_index_data *oi, *oi2;
     char buf[80];
 
     which_i = obj_index;

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -3179,10 +3179,38 @@ void do_show(struct char_data *ch, char *argument,
 
 
   }
-  else if ((is_abbrev(buf, "objects") &&
-            (which_i = obj_index, topi = top_of_objt)) ||
-           (is_abbrev(buf, "mobiles") &&
-            (which_i = mob_index, topi = top_of_mobt))) {
+  else if (is_abbrev(buf, "mobiles")) {
+    topi = top_of_mobt;
+    int objn;
+    struct mob_index_data *mi;
+
+    only_argument(argument, zonenum);
+    zone = -1;
+    if (1 == sscanf(zonenum, "%i", &zone) &&
+        (zone < 0 || zone > top_of_zone_table)) {
+      append_to_string_block(&sb, "That is not a valid zone_number\n\r");
+      return;
+    }
+    if (zone >= 0) {
+      bottom = zone ? (zone_table[zone - 1].top + 1) : 0;
+      top = zone_table[zone].top;
+    }
+
+    append_to_string_block(&sb, "VNUM  rnum count names\n\r");
+    for (objn = 0; objn <= topi; objn++) {
+      mi = mob_index + objn;
+
+      if ((zone >= 0 && (mi->virtual < bottom || mi->virtual > top)) ||
+          (zone < 0 && !isname(zonenum, mi->name)))
+        continue;               /* optimize later */
+
+      SPRINTF(buf, "%5d %4d %3d  %s\n\r", mi->virtual, objn,
+              mi->number, mi->name);
+      append_to_string_block(&sb, buf);
+    }
+  }
+  else if (is_abbrev(buf, "objects")) {
+    topi = top_of_objt;
     int objn;
     struct obj_index_data *oi;
 
@@ -3200,7 +3228,7 @@ void do_show(struct char_data *ch, char *argument,
 
     append_to_string_block(&sb, "VNUM  rnum count names\n\r");
     for (objn = 0; objn <= topi; objn++) {
-      oi = which_i + objn;
+      oi = obj_index + objn;
 
       if ((zone >= 0 && (oi->virtual < bottom || oi->virtual > top)) ||
           (zone < 0 && !isname(zonenum, oi->name)))
@@ -3212,7 +3240,7 @@ void do_show(struct char_data *ch, char *argument,
     }
 
 
-  }
+  }  
   else if (is_abbrev(buf, "rooms")) {
 
     only_argument(argument, zonenum);

--- a/src/db.c
+++ b/src/db.c
@@ -154,7 +154,8 @@ void boot_db() {
   log_msg("Generating index tables for mobile and object files.");
   mob_index = make_mob_indices(generate_indices(mob_f, &top_of_mobt),
                                top_of_mobt);
-  obj_index = generate_indices(obj_f, &top_of_objt);
+  obj_index = make_obj_indices(generate_indices(obj_f, &top_of_objt),
+                               top_of_objt);
 
   log_msg("Renumbering zone table.");
   renum_zone_table();
@@ -656,6 +657,27 @@ struct mob_index_data *make_mob_indices(struct index_data *base_idx,
     free(base_idx);
   }
   return mob_idx;
+}
+
+struct obj_index_data *make_obj_indices(struct index_data *base_idx,
+                                        int top) {
+  struct obj_index_data *obj_idx = NULL;
+
+  if (base_idx) {
+    CREATE(obj_idx, struct obj_index_data, top + 1);
+
+    for (int i = 0; i < top + 1; i++) {
+      obj_idx[i].virtual = base_idx[i].virtual;
+      obj_idx[i].pos = base_idx[i].pos;
+      obj_idx[i].number = base_idx[i].number;
+      obj_idx[i].func = (obj_func*)base_idx[i].func;
+      obj_idx[i].name = base_idx[i].name;
+      obj_idx[i].short_desc = base_idx[i].short_desc;
+      obj_idx[i].long_desc = base_idx[i].long_desc;
+    }
+    free(base_idx);
+  }
+  return obj_idx;
 }
 
 /* generate index table for object or monster file */
@@ -3164,9 +3186,10 @@ void reboot_text(struct char_data *ch, char *UNUSED(arg),
 
 
   log_msg("Generating index tables for mobile and object files.");
-  mob_index = (struct mob_index_data*)generate_indices(mob_f,
-                                                       &top_of_mobt);
-  obj_index = generate_indices(obj_f, &top_of_objt);
+  mob_index = make_mob_indices(generate_indices(mob_f, &top_of_mobt),
+                               top_of_mobt);
+  obj_index = make_obj_indices(generate_indices(obj_f, &top_of_objt),
+                               top_of_objt);
 
 /* log_msg("Initializing Scripts.");
  init_scripts();

--- a/src/db.c
+++ b/src/db.c
@@ -69,7 +69,7 @@ FILE *mob_f,                    /* file containing mob prototypes  */
  *help_fl;                      /* file for help texts (HELP <kwd>) */
 
 struct mob_index_data *mob_index;   /* index table for mobile file     */
-struct index_data *obj_index;   /* index table for object file     */
+struct obj_index_data *obj_index;   /* index table for object file     */
 struct help_index_element *help_index = 0;
 
 int top_of_mobt = 0;            /* top of mobile index table       */
@@ -638,7 +638,7 @@ void build_player_index() {
 }
 
 
-struct mob_index_data *make_mob_indices(struct index_data *base_idx,
+struct mob_index_data *make_mob_indices(struct _index_data *base_idx,
                                         int top) {
   struct mob_index_data *mob_idx = NULL;
 
@@ -659,7 +659,7 @@ struct mob_index_data *make_mob_indices(struct index_data *base_idx,
   return mob_idx;
 }
 
-struct obj_index_data *make_obj_indices(struct index_data *base_idx,
+struct obj_index_data *make_obj_indices(struct _index_data *base_idx,
                                         int top) {
   struct obj_index_data *obj_idx = NULL;
 
@@ -681,10 +681,10 @@ struct obj_index_data *make_obj_indices(struct index_data *base_idx,
 }
 
 /* generate index table for object or monster file */
-struct index_data *generate_indices(FILE * fl, int *top) {
+struct _index_data *generate_indices(FILE * fl, int *top) {
   int i = 0;
   long bc = 1500;
-  struct index_data *index;
+  struct _index_data *index;
   char buf[82];
 
   rewind(fl);
@@ -693,12 +693,12 @@ struct index_data *generate_indices(FILE * fl, int *top) {
     if (fgets(buf, sizeof(buf), fl)) {
       if (*buf == '#') {
         if (!i) {               /* first cell */
-          CREATE(index, struct index_data, bc);
+          CREATE(index, struct _index_data, bc);
         }
         else {
           if (i >= bc) {
-            if (!(index = (struct index_data *)
-                  realloc(index, (i + 50) * sizeof(struct index_data)))) {
+            if (!(index = (struct _index_data *)
+                  realloc(index, (i + 50) * sizeof(struct _index_data)))) {
               perror("load indices");
               assert(0);
             }

--- a/src/db.c
+++ b/src/db.c
@@ -68,7 +68,7 @@ FILE *mob_f,                    /* file containing mob prototypes  */
  *obj_f,                        /* obj prototypes                  */
  *help_fl;                      /* file for help texts (HELP <kwd>) */
 
-struct index_data *mob_index;   /* index table for mobile file     */
+struct mob_index_data *mob_index;   /* index table for mobile file     */
 struct index_data *obj_index;   /* index table for object file     */
 struct help_index_element *help_index = 0;
 
@@ -152,7 +152,8 @@ void boot_db() {
 
 
   log_msg("Generating index tables for mobile and object files.");
-  mob_index = generate_indices(mob_f, &top_of_mobt);
+  mob_index = make_mob_indices(generate_indices(mob_f, &top_of_mobt),
+                               top_of_mobt);
   obj_index = generate_indices(obj_f, &top_of_objt);
 
   log_msg("Renumbering zone table.");
@@ -636,7 +637,26 @@ void build_player_index() {
 }
 
 
+struct mob_index_data *make_mob_indices(struct index_data *base_idx,
+                                        int top) {
+  struct mob_index_data *mob_idx = NULL;
 
+  if (base_idx) {
+    CREATE(mob_idx, struct mob_index_data, top + 1);
+
+    for (int i = 0; i < top + 1; i++) {
+      mob_idx[i].virtual = base_idx[i].virtual;
+      mob_idx[i].pos = base_idx[i].pos;
+      mob_idx[i].number = base_idx[i].number;
+      mob_idx[i].func = (mob_func*)base_idx[i].func;
+      mob_idx[i].name = base_idx[i].name;
+      mob_idx[i].short_desc = base_idx[i].short_desc;
+      mob_idx[i].long_desc = base_idx[i].long_desc;
+    }
+    free(base_idx);
+  }
+  return mob_idx;
+}
 
 /* generate index table for object or monster file */
 struct index_data *generate_indices(FILE * fl, int *top) {
@@ -3144,7 +3164,8 @@ void reboot_text(struct char_data *ch, char *UNUSED(arg),
 
 
   log_msg("Generating index tables for mobile and object files.");
-  mob_index = generate_indices(mob_f, &top_of_mobt);
+  mob_index = (struct mob_index_data*)generate_indices(mob_f,
+                                                       &top_of_mobt);
   obj_index = generate_indices(obj_f, &top_of_objt);
 
 /* log_msg("Initializing Scripts.");

--- a/src/db.c
+++ b/src/db.c
@@ -649,10 +649,10 @@ struct mob_index_data *make_mob_indices(struct index_data *base_idx,
       mob_idx[i].virtual = base_idx[i].virtual;
       mob_idx[i].pos = base_idx[i].pos;
       mob_idx[i].number = base_idx[i].number;
-      mob_idx[i].func = (mob_func*)base_idx[i].func;
       mob_idx[i].name = base_idx[i].name;
       mob_idx[i].short_desc = base_idx[i].short_desc;
       mob_idx[i].long_desc = base_idx[i].long_desc;
+      mob_idx[i].func = NULL;
     }
     free(base_idx);
   }
@@ -670,10 +670,10 @@ struct obj_index_data *make_obj_indices(struct index_data *base_idx,
       obj_idx[i].virtual = base_idx[i].virtual;
       obj_idx[i].pos = base_idx[i].pos;
       obj_idx[i].number = base_idx[i].number;
-      obj_idx[i].func = (obj_func*)base_idx[i].func;
       obj_idx[i].name = base_idx[i].name;
       obj_idx[i].short_desc = base_idx[i].short_desc;
       obj_idx[i].long_desc = base_idx[i].long_desc;
+      obj_idx[i].func = NULL;
     }
     free(base_idx);
   }
@@ -708,7 +708,6 @@ struct index_data *generate_indices(FILE * fl, int *top) {
         sscanf(buf, "#%d", &index[i].virtual);
         index[i].pos = ftell(fl);
         index[i].number = 0;
-        index[i].func = 0;
         index[i].name = (index[i].virtual < 99999) ? fread_string(fl) :
           strdup("omega");
         i++;

--- a/src/db.h
+++ b/src/db.h
@@ -173,4 +173,7 @@ char *fread_string(FILE *f1);
 int fread_string_na(char *dst, size_t max_len, FILE *f1);
 void reboot_text(struct char_data *ch, char *arg, const char * cmd);
 
+struct mob_index_data *make_mob_indices(struct index_data *base_idx, int top);
+struct index_data *generate_indices(FILE * fl, int *top);
+
 #endif

--- a/src/db.h
+++ b/src/db.h
@@ -83,17 +83,10 @@ struct zone_data {
 
 
 /* element in monster and object index-tables   */
-struct index_data {
+struct _index_data {
   int virtual;                  /* virtual number of this mob/obj           */
   long pos;                     /* file position of this field              */
   int number;                   /* number of existing units of this mob/obj   */
-
-  /* mob special procs are:
-     int (*func)(struct char_data *, int, char *, char *, int);
-     obj special procs are:
-     int (*func)(struct char_data *, int, char *, struct obj_data *, int);
-   */
-  int (*func) ();
   char *name;
   char *short_desc;
   char *long_desc;
@@ -123,6 +116,8 @@ struct mob_index_data {
   char *long_desc;
 };
 
+extern struct mob_index_data *mob_index;   /* index table for mobile file     */
+extern struct index_data *obj_index;   /* index table for object file     */
 extern int top_of_mobt;
 extern int top_of_objt;
 
@@ -176,5 +171,6 @@ void reboot_text(struct char_data *ch, char *arg, const char * cmd);
 struct mob_index_data *make_mob_indices(struct index_data *base_idx, int top);
 struct obj_index_data *make_obj_indices(struct index_data *base_idx, int top);
 struct index_data *generate_indices(FILE * fl, int *top);
+
 
 #endif

--- a/src/db.h
+++ b/src/db.h
@@ -92,7 +92,8 @@ struct _index_data {
   char *long_desc;
 };
 
-typedef int (obj_func)(struct char_data*, int, char*, struct obj_data*, int);
+typedef int (obj_func)(struct char_data*, const char *, char*,
+                       struct obj_data*, int);
 
 struct obj_index_data {
   int virtual;                  /* virtual number of this mob/obj           */
@@ -104,7 +105,8 @@ struct obj_index_data {
   char *long_desc;
 };
 
-typedef int (mob_func)(struct char_data*, int, char*, int);
+typedef int (mob_func)(struct char_data*, const char *, char*,
+                       struct char_data*, int);
 
 struct mob_index_data {
   int virtual;                  /* virtual number of this mob/obj           */
@@ -117,7 +119,7 @@ struct mob_index_data {
 };
 
 extern struct mob_index_data *mob_index;   /* index table for mobile file     */
-extern struct index_data *obj_index;   /* index table for object file     */
+extern struct obj_index_data *obj_index;   /* index table for object file     */
 extern int top_of_mobt;
 extern int top_of_objt;
 
@@ -168,9 +170,11 @@ char *fread_string(FILE *f1);
 int fread_string_na(char *dst, size_t max_len, FILE *f1);
 void reboot_text(struct char_data *ch, char *arg, const char * cmd);
 
-struct mob_index_data *make_mob_indices(struct index_data *base_idx, int top);
-struct obj_index_data *make_obj_indices(struct index_data *base_idx, int top);
-struct index_data *generate_indices(FILE * fl, int *top);
+struct mob_index_data *make_mob_indices(struct _index_data *base_idx, int top);
+struct obj_index_data *make_obj_indices(struct _index_data *base_idx, int top);
+struct _index_data *generate_indices(FILE * fl, int *top);
+
+extern struct obj_data *object_list;
 
 
 #endif

--- a/src/db.h
+++ b/src/db.h
@@ -174,6 +174,7 @@ int fread_string_na(char *dst, size_t max_len, FILE *f1);
 void reboot_text(struct char_data *ch, char *arg, const char * cmd);
 
 struct mob_index_data *make_mob_indices(struct index_data *base_idx, int top);
+struct obj_index_data *make_obj_indices(struct index_data *base_idx, int top);
 struct index_data *generate_indices(FILE * fl, int *top);
 
 #endif

--- a/src/db.h
+++ b/src/db.h
@@ -99,6 +99,30 @@ struct index_data {
   char *long_desc;
 };
 
+typedef int (obj_func)(struct char_data*, int, char*, struct obj_data*, int);
+
+struct obj_index_data {
+  int virtual;                  /* virtual number of this mob/obj           */
+  long pos;                     /* file position of this field              */
+  int number;                   /* number of existing units of this mob/obj   */
+  obj_func *func;
+  char *name;
+  char *short_desc;
+  char *long_desc;
+};
+
+typedef int (mob_func)(struct char_data*, int, char*, int);
+
+struct mob_index_data {
+  int virtual;                  /* virtual number of this mob/obj           */
+  long pos;                     /* file position of this field              */
+  int number;                   /* number of existing units of this mob/obj   */
+  mob_func *func;
+  char *name;
+  char *short_desc;
+  char *long_desc;
+};
+
 extern int top_of_mobt;
 extern int top_of_objt;
 

--- a/src/db.h
+++ b/src/db.h
@@ -86,7 +86,7 @@ struct zone_data {
 struct _index_data {
   int virtual;                  /* virtual number of this mob/obj           */
   long pos;                     /* file position of this field              */
-  int number;                   /* number of existing units of this mob/obj   */
+  int number;                   /* number of existing units of this mob/obj */
   char *name;
   char *short_desc;
   char *long_desc;
@@ -96,9 +96,9 @@ typedef int (obj_func)(struct char_data*, const char *, char*,
                        struct obj_data*, int);
 
 struct obj_index_data {
-  int virtual;                  /* virtual number of this mob/obj           */
-  long pos;                     /* file position of this field              */
-  int number;                   /* number of existing units of this mob/obj   */
+  int virtual;                  /* virtual number of this obj           */
+  long pos;                     /* file position of this field          */
+  int number;                   /* number of existing units of this obj */
   obj_func *func;
   char *name;
   char *short_desc;
@@ -109,17 +109,17 @@ typedef int (mob_func)(struct char_data*, const char *, char*,
                        struct char_data*, int);
 
 struct mob_index_data {
-  int virtual;                  /* virtual number of this mob/obj           */
-  long pos;                     /* file position of this field              */
-  int number;                   /* number of existing units of this mob/obj   */
+  int virtual;                  /* virtual number of this mob           */
+  long pos;                     /* file position of this field          */
+  int number;                   /* number of existing units of this mob */
   mob_func *func;
   char *name;
   char *short_desc;
   char *long_desc;
 };
 
-extern struct mob_index_data *mob_index;   /* index table for mobile file     */
-extern struct obj_index_data *obj_index;   /* index table for object file     */
+extern struct mob_index_data *mob_index;   /* index table for mobile file */
+extern struct obj_index_data *obj_index;   /* index table for object file */
 extern int top_of_mobt;
 extern int top_of_objt;
 

--- a/src/fight.c
+++ b/src/fight.c
@@ -42,7 +42,6 @@ extern struct room_data *room_db;
 extern struct message_list fight_messages[MAX_MESSAGES];
 extern struct char_data *character_list;
 extern struct skill_data skill_info[];
-extern struct index_data *obj_index;
 extern char *ItemDamType[];
 extern int item_saveThrows[22][5];
 extern struct str_app_type str_app[];

--- a/src/fight.c
+++ b/src/fight.c
@@ -14,6 +14,7 @@
 #include "act.other.h"
 #include "act.off.h"
 #include "utility.h"
+#include "db.h"
 
 #define DUAL_WIELD(ch) (ch->equipment[WIELD] && ch->equipment[HOLD]&&\
 			ITEM_TYPE(ch->equipment[WIELD])==ITEM_WEAPON && \
@@ -39,8 +40,6 @@ extern struct hash_header room_db;
 extern struct room_data *room_db;
 #endif
 extern struct message_list fight_messages[MAX_MESSAGES];
-extern struct obj_data *object_list;
-extern struct index_data *mob_index;
 extern struct char_data *character_list;
 extern struct skill_data skill_info[];
 extern struct index_data *obj_index;

--- a/src/handler.c
+++ b/src/handler.c
@@ -15,6 +15,7 @@
 #include "act.wizard.h"
 #include "act.other.h"
 #include "utility.h"
+#include "db.h"
 
 #if HASH
 extern struct hash_header room_db;
@@ -23,8 +24,6 @@ extern struct room_data *room_db;
 #endif
 extern struct obj_data *object_list;
 extern struct char_data *character_list;
-extern struct index_data *mob_index;
-extern struct index_data *obj_index;
 extern struct descriptor_data *descriptor_list;
 extern struct str_app_type str_app[];
 extern struct dex_app_type dex_app[];

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -33,6 +33,7 @@
 #include "act.social.h"
 #include "spell_parser.h"
 #include "utility.h"
+#include "db.h"
 
 #define NOT !
 #define AND &&
@@ -48,8 +49,6 @@ extern char wmotd[MAX_STRING_LENGTH];
 extern struct char_data *character_list;
 extern struct player_index_element *player_table;
 extern int top_of_p_table;
-extern struct index_data *mob_index;
-extern struct index_data *obj_index;
 #if HASH
 extern struct hash_header room_db;
 #else

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -1855,7 +1855,7 @@ void spell_silence(byte level, struct char_data *ch,
       if ((!victim->specials.fighting)) {
         set_fighting(victim, ch);
         if (mob_index[victim->nr].func) {
-          (*mob_index[victim->nr].func) (victim, 0, "");
+          (*mob_index[victim->nr].func) (victim, 0, "", NULL, 0);
         }
       }
     }

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -16,6 +16,7 @@
 #include "act.info.h"
 #include "act.off.h"
 #include "utility.h"
+#include "db.h"
 
 /* Extern structures */
 extern struct room_data *world;
@@ -1833,7 +1834,6 @@ void spell_gust_of_wind(byte level, struct char_data *ch,
 void spell_silence(byte level, struct char_data *ch,
                    struct char_data *victim, struct obj_data *UNUSED(obj)) {
   struct affected_type af;
-  extern struct index_data *mob_index;
 
   assert(ch && victim);
 

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -16,16 +16,15 @@
 #include "act.off.h"
 #include "act.wizard.h"
 #include "utility.h"
+#include "db.h"
 
 extern struct char_data *character_list;
-extern struct index_data *mob_index;
 #if HASH
 extern struct hash_header room_db;
 #else
 extern struct room_data *room_db;
 #endif
 extern struct str_app_type str_app[];
-extern struct index_data *mob_index;
 
 int top_of_comp = 0;
 

--- a/src/protos.h
+++ b/src/protos.h
@@ -233,7 +233,6 @@ void boot_db();
 void reset_time();
 void update_time();
 void build_player_index();
-struct index_data *generate_indices(FILE * fl, int *top);
 void cleanout_room(struct room_data *rp);
 void completely_cleanout_room(struct room_data *rp);
 void load_one_room(FILE * fl, struct room_data *rp);

--- a/src/protos.h
+++ b/src/protos.h
@@ -956,7 +956,6 @@ void shopping_list(char *arg, struct char_data *ch,
                    struct char_data *keeper, int shop_nr);
 void shopping_kill(char *arg, struct char_data *ch,
                    struct char_data *keeper, int shop_nr);
-int shop_keeper(struct char_data *ch, int cmd, char *arg, char *mob, int type);
 void boot_the_shops();
 void assign_the_shopkeepers();
 int do_i_hate_you(struct char_data *v);

--- a/src/reception.c
+++ b/src/reception.c
@@ -21,12 +21,11 @@
 #include "utility.h"
 #include "spec_procs.h"
 #include "utility.h"
+#include "db.h"
 
 #define OBJ_FILE_FREE "\0\0\0"
 
 extern struct room_data *world;
-extern struct index_data *mob_index;
-extern struct index_data *obj_index;
 extern int top_of_objt;
 extern struct player_index_element *player_table;
 extern int top_of_p_table;

--- a/src/shop.c
+++ b/src/shop.c
@@ -17,6 +17,8 @@
 #include "act.comm.h"
 #include "utility.h"
 #include "db.h"
+#include "shop.h"
+#include "spec_procs.h"
 
 #define SHOP_FILE "tinyworld.shp"
 #define MAX_TRADE 5
@@ -553,15 +555,12 @@ void shopping_kill(char *UNUSED(arg), struct char_data *ch,
   }
 }
 
-int shop_keeper(struct char_data *ch, int cmd, char *arg, char *UNUSED(mob),
-                int type) {
+int shop_keeper(struct char_data *ch, const char *cmd, char *arg,
+                struct char_data *UNUSED(mob), int type) {
   char argm[100];
   struct char_data *temp_char;
   struct char_data *keeper;
   int shop_nr;
-
-  int citizen(struct char_data *ch, int cmd, char *arg, struct char_data *mob,
-              int type);
 
   if (type == EVENT_DWARVES_STRIKE) {
     ch->generic = DWARVES_STRIKE;
@@ -600,35 +599,35 @@ int shop_keeper(struct char_data *ch, int cmd, char *arg, char *UNUSED(mob),
     act("$n sneers at $N.", TRUE, keeper, 0, ch, TO_NOTVICT);
   }
 
-  if ((cmd == 56) && (ch->in_room == shop_index[shop_nr].in_room))
-    /* Buy */
+  if (STREQ(cmd, "buy") &&
+      (ch->in_room == shop_index[shop_nr].in_room))
   {
     shopping_buy(arg, ch, keeper, shop_nr);
     return (TRUE);
   }
 
-  if ((cmd == 57) && (ch->in_room == shop_index[shop_nr].in_room))
-    /* Sell */
+  if (STREQ(cmd, "sell") &&
+      (ch->in_room == shop_index[shop_nr].in_room))
   {
     shopping_sell(arg, ch, keeper, shop_nr);
     return (TRUE);
   }
 
-  if ((cmd == 58) && (ch->in_room == shop_index[shop_nr].in_room))
-    /* value */
+  if ((STREQ(cmd, "value") &&
+       (ch->in_room == shop_index[shop_nr].in_room)))
   {
     shopping_value(arg, ch, keeper, shop_nr);
     return (TRUE);
   }
 
-  if ((cmd == 59) && (ch->in_room == shop_index[shop_nr].in_room))
-    /* List */
+  if (STREQ(cmd, "list") &&
+      (ch->in_room == shop_index[shop_nr].in_room))
   {
     shopping_list(arg, ch, keeper, shop_nr);
     return (TRUE);
   }
 
-  if ((cmd == 25) || (cmd == 70)) {     /* Kill or Hit */
+  if (STREQ(cmd, "hit") || STREQ(cmd, "kill")) {
     only_argument(arg, argm);
 
     if (keeper == get_char_room(argm, ch->in_room)) {
@@ -636,7 +635,9 @@ int shop_keeper(struct char_data *ch, int cmd, char *arg, char *UNUSED(mob),
       return (TRUE);
     }
   }
-  else if ((cmd == 84) || (cmd == 207) || (cmd == 172)) {       /* Cast, recite, use */
+  else if (STREQ(cmd, "cast") ||
+           STREQ(cmd, "recite") ||
+           STREQ(cmd, "use")) {
     act("$N tells you 'No magic here - kid!'.", FALSE, ch, 0, keeper, TO_CHAR);
     return TRUE;
   }

--- a/src/shop.c
+++ b/src/shop.c
@@ -16,6 +16,7 @@
 #include "act.social.h"
 #include "act.comm.h"
 #include "utility.h"
+#include "db.h"
 
 #define SHOP_FILE "tinyworld.shp"
 #define MAX_TRADE 5
@@ -23,7 +24,6 @@
 
 
 extern struct str_app_type str_app[];
-extern struct index_data *mob_index;
 extern struct chr_app_type chr_apply[];
 
 char *fread_string(FILE * fl);

--- a/src/shop.h
+++ b/src/shop.h
@@ -1,0 +1,7 @@
+#ifndef SHOP_H
+#define SHOP_H
+
+int shop_keeper(struct char_data *, const char *, char *, struct char_data *,
+                int);
+
+#endif

--- a/src/skills.c
+++ b/src/skills.c
@@ -15,6 +15,7 @@
 #include "act.obj1.h"
 #include "act.info.h"
 #include "utility.h"
+#include "db.h"
 
 extern char *dirs[];
 extern struct char_data *character_list;
@@ -22,7 +23,6 @@ extern struct str_app_type str_app[];
 extern struct room_data *world;
 extern struct dex_app_type dex_app[];
 extern struct skill_data skill_info[];
-extern struct index_data *obj_index;
 
 struct hunting_data {
   char *name;
@@ -1584,7 +1584,6 @@ void do_makepotion(struct char_data *ch, char *argument,
   struct obj_data *o, *in_o, *next, *potion;
   struct room_data *rp;
 
-  extern struct index_data *obj_index;
   extern struct BrewMeister BrewList[MAX_POTIONS];
 
   for (i = 0; i < 5; i++)       /* very important indeed */

--- a/src/spec_assign.c
+++ b/src/spec_assign.c
@@ -16,14 +16,13 @@
 #include "spec_procs3.h"
 #include "reception.h"
 #include "utility.h"
+#include "db.h"
 
 #if HASH
 extern struct hash_header room_db;
 #else
 extern struct room_data *room_db;
 #endif
-extern struct index_data *mob_index;
-extern struct index_data *obj_index;
 void boot_the_shops();
 void assign_the_shopkeepers();
 

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -24,6 +24,7 @@
 #include "spec_procs2.h"
 #include "spec_procs3.h"
 #include "utility.h"
+#include "db.h"
 
 #define INQ_SHOUT 1
 #define INQ_LOOSE 0
@@ -42,9 +43,7 @@
 extern struct room_data *world;
 extern struct char_data *character_list;
 extern struct descriptor_data *descriptor_list;
-extern struct index_data *obj_index;
 extern struct time_info_data time_info;
-extern struct index_data *mob_index;
 extern struct weather_data weather_info;
 extern int top_of_world;
 extern struct int_app_type int_app[26];

--- a/src/spec_procs.h
+++ b/src/spec_procs.h
@@ -193,5 +193,6 @@ int guardian(struct char_data *ch, const char *cmd, char *arg, struct char_data 
 int web_slinger(struct char_data *ch, const char *cmd, char *arg,
                 struct char_data *mob, int type);
 
+int citizen(struct char_data *, const char *, char *, struct char_data *, int);
 
 #endif

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -22,15 +22,14 @@
 #include "spec_procs2.h"
 #include "spec_procs3.h"
 #include "utility.h"
+#include "db.h"
 
 /*   external vars  */
 
 extern struct room_data *world;
 extern struct char_data *character_list;
 extern struct descriptor_data *descriptor_list;
-extern struct index_data *obj_index;
 extern struct time_info_data time_info;
-extern struct index_data *mob_index;
 extern struct weather_data weather_info;
 extern int top_of_world;
 extern struct int_app_type int_app[26];

--- a/src/spec_procs3.c
+++ b/src/spec_procs3.c
@@ -19,15 +19,14 @@
 #include "spec_procs.h"
 #include "spec_procs2.h"
 #include "spec_procs3.h"
+#include "db.h"
 
 /*   external vars  */
 
 extern struct room_data *world;
 extern struct char_data *character_list;
 extern struct descriptor_data *descriptor_list;
-extern struct index_data *obj_index;
 extern struct time_info_data time_info;
-extern struct index_data *mob_index;
 extern struct weather_data weather_info;
 extern int top_of_world;
 extern struct int_app_type int_app[26];

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -15,6 +15,7 @@
 #include "act.off.h"
 #include "act.other.h"
 #include "utility.h"
+#include "db.h"
 
 /* because I don't want to recompile */
 
@@ -53,7 +54,6 @@ extern char *spell_wear_off_soon_msg[];
 extern char *spell_wear_off_room_msg[];
 extern char *spell_wear_off_soon_room_msg[];
 extern struct obj_data *object_list;
-extern struct index_data *obj_index;
 extern struct con_app_type con_app[];
 extern struct weather_data weather_info;
 extern int sf_where[];

--- a/src/spells2.c
+++ b/src/spells2.c
@@ -11,6 +11,7 @@
 
 #include "protos.h"
 #include "utility.h"
+#include "db.h"
 
 /* Global data */
 
@@ -23,7 +24,6 @@ extern char *dirs[];
 extern int movement_loss[];
 extern struct weather_data weather_info;
 extern struct time_info_data time_info;
-extern struct index_data *obj_index;
 struct PolyType DruidList[17];
 /* Extern procedures */
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -19,6 +19,7 @@
 #include "act.info.h"
 #include "act.other.h"
 #include "act.move.h"
+#include "db.h"
 
 void log_msg(char *s) {
   log_sev(s, 1);
@@ -37,7 +38,6 @@ extern char *article_list[];
 extern struct time_data time_info;
 extern struct descriptor_data *descriptor_list;
 extern struct char_data *character_list;
-extern struct index_data *mob_index, *obj_index;
 extern struct chr_app_type chr_apply[];
 #if HASH
 extern struct hash_header room_db;      /* In db.c */


### PR DESCRIPTION
This PR splits up a lot of the code that makes objects and mobs look identical. They have different function signatures, though, so there was zero type checking being done when special functions were assigned. Splitting them up closes that bug hole.
