### PR TITLE
Add command-line option for daemon (background) mode.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,11 +15,11 @@ common_sources = comm.c act.comm.c act.info.c act.move.c act.obj1.c \
 	act.comm.h act.info.h act.move.h act.obj1.h act.obj2.h act.off.h \
 	act.other.h act.social.h act.wizard.h area.h board.h comm.h create.h \
 	db.h debug.h fight.h handler.h hash.h heap.h interpreter.h \
-	intrinsics.h limits.h memory.h mobact.h modify.h parser.h poly.h \
-	protos.h race.h reception.h script.h security.h shop.h skills.h \
-	spec_procs.h spec_procs2.h spec_procs3.h spell_parser.h spells.h \
-	spells1.h spells2.h structs.h temp.h trap.h utility.h utils.h \
-	vt100c.h wizlist.h
+	intrinsics.h limits.h memory.h mobact.h modify.h options.h parser.h \
+	poly.h protos.h race.h reception.h script.h security.h shop.h \
+	skills.h spec_procs.h spec_procs2.h spec_procs3.h spell_parser.h \
+	spells.h spells1.h spells2.h structs.h temp.h trap.h utility.h \
+	utils.h vt100c.h wizlist.h
 sillymud_SOURCES = $(common_sources) main.c
 
 # unit tests

--- a/src/comm.h
+++ b/src/comm.h
@@ -20,5 +20,6 @@
 #define PLAYER_AUTH 0
 
 void send_to_charf(struct char_data *ch, const char *fmt, ...);
+void run_as_daemon();
 
 #endif

--- a/src/options.h
+++ b/src/options.h
@@ -1,0 +1,7 @@
+#ifndef _OPTIONS_H
+#define _OPTIONS_H
+
+/* global option flags */
+extern int daemon_mode;
+
+#endif /* _OPTIONS_H */

--- a/src/utility.c
+++ b/src/utility.c
@@ -14,6 +14,7 @@
 #include <syslog.h>
 
 #include "protos.h"
+#include "options.h"
 #include "utility.h"
 #include "act.off.h"
 #include "skills.h"
@@ -27,8 +28,12 @@ void vlog_lev_msgf(int level, const char *fmt, va_list args) {
   char buf[256];
   va_list nargs;
   va_copy(nargs, args);
-  vsyslog(level, fmt, args);
-  vsnprintf(buf, sizeof(buf), fmt, nargs);
+  vsnprintf(buf, sizeof(buf)-1, fmt, nargs);
+  if (daemon_mode) {
+    vsyslog(level, fmt, args);
+  } else {
+    printf("%s\n", buf);
+  }
   va_end(nargs);
   log_wiz(buf, level);
 }


### PR DESCRIPTION
- Introduced a file `options.h` where `extern` declarations for
  global option flags can be referenced.
- When _not_ running in daemon mode, log to stdout instead of to
  syslog.
- Print usage message and exit if passed an unrecognized option.

Addresses #55.
