### PR TITLE
Separate out temporary index from type-specific index creation.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -96,6 +96,7 @@ int verify_mob(struct char_data *ch);
 void boot_db() {
   int i;
   extern int no_specials;
+  struct _index_data *base_mob_idx, *base_obj_idx;
 
   log_msg("Boot db -- BEGIN.");
 
@@ -152,10 +153,10 @@ void boot_db() {
 
 
   log_msg("Generating index tables for mobile and object files.");
-  mob_index = make_mob_indices(generate_indices(mob_f, &top_of_mobt),
-                               top_of_mobt);
-  obj_index = make_obj_indices(generate_indices(obj_f, &top_of_objt),
-                               top_of_objt);
+  base_mob_idx = generate_indices(mob_f, &top_of_mobt);
+  mob_index = make_mob_indices(base_mob_idx, top_of_mobt);
+  base_obj_idx = generate_indices(obj_f, &top_of_objt);
+  obj_index = make_obj_indices(base_obj_idx, top_of_objt);
 
   log_msg("Renumbering zone table.");
   renum_zone_table();


### PR DESCRIPTION
It turns out that not the right thing was going on here. The
intent was that the initial call to `generate_indices` would
populate `top_of_mobt` or `top_of_objt`, which would then be
passed as the second argument to either `make_mob_indices` or
`make_obj_indices`. This works locally for me on Mac OS X with
the Apple LLVM-based `gcc`.

However, when running on the prod Linux machine when compiled
with `gcc` 4.8.3, the order of operations doesn't come out
right. In this case, the _original_ value for `top_of_mobt` or
`top_of_objt` gets passed in: `0`, and hence the new indices
don't get created correctly.

By un-lining the call to `generate_indices` we can make sure
it is unambiguous what order we want these to happen in.
