### PR TITLE
Check distributed package for buildability in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ addons:
     - check
 install:
   - ./ci/install-dependencies.sh
-script: CFLAGS="-std=gnu99 -Wall -Wextra -Werror -I`pwd`/Criterion/include" LDFLAGS="-L`pwd`/Criterion/build -Wl,-R -Wl,`pwd`/Criterion/build" ./configure && make && make check
+script: CFLAGS="-std=gnu99 -Wall -Wextra -Werror -I`pwd`/Criterion/include" LDFLAGS="-L`pwd`/Criterion/build -Wl,-R -Wl,`pwd`/Criterion/build" ./configure && make && make check && ./ci/check-dist.sh

--- a/ci/check-dist.sh
+++ b/ci/check-dist.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+VERSION=`git describe`
+
+set -e
+
+make dist
+tar zxvf sillymud-$VERSION.tar.gz
+(cd sillymud-$VERSION; CFLAGS="-std=gnu99" ./configure && make)
+
+


### PR DESCRIPTION
A couple of times I've forgotten to add a `.h` file to the list
of source files in `src/Makefile.am`, for example. This should
catch that.

Implements #62.
