### PR TITLE
Fix learning at ninja master.

### DIFF
--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -1266,8 +1266,8 @@ int teacher(struct char_data *ch, const char *cmd, char *arg,
 
     if (ch->skills[number].learned >= 95) {
       send_to_char("'You are now a master of this art.'\n\r", ch);
-      return (TRUE);
     }
+    return (TRUE);
   }
   return (FALSE);
 }


### PR DESCRIPTION
Special procs return TRUE if they handle a command; in this case
a successful practice at the ninja master was not returning it
from the right place, and it was falling through to the default
FALSE, which is why it got handled by the `do_practice` command
in addition.

Addresses #81.
