### PR TITLE
Tidy up version numbering.

### DIFF
--- a/ci/check-dist.sh
+++ b/ci/check-dist.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=`git describe`
+VERSION=`git describe --match 'v*' | sed -e 's/^v//'`
 
 set -e
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-AC_INIT([sillymud], m4_esyscmd_s(git describe), [], [], [https://github.com/jonm/SillyMUD])
+AC_INIT([sillymud], m4_esyscmd_s(git describe --match 'v*' | sed -e 's/^v//'), [], [], [https://github.com/jonm/SillyMUD])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
We (ok, I) have been doing git tags for releases like "v0.1.9"
but this results in the use of that version string downstream.
For example, `make dist` will produce `sillymud-v0.1.9.tar.gz`
instead of the desired `sillymud-0.1.9.tar.gz`. This change
just strips the leading `v` off the tag name to use for the
_autotools_ version.

However, I would also be ok with going back through to update
the git tags to be the version numbers we want (`0.1.9`) under
the assumption that probably no one would care. Putting this
PR to collect opinions on the best path forward.
