### PR TITLE
Fix warnings

### DIFF
--- a/src/act.comm.c
+++ b/src/act.comm.c
@@ -24,7 +24,7 @@ extern const char *ogre_speak[];
 
 void do_say(struct char_data *ch, char *argument,
             const char * UNUSED(cmd)) {
-  char buf[MAX_INPUT_LENGTH + 40], buf2[MAX_INPUT_LENGTH + 40];
+  char buf[MAX_INPUT_LENGTH * 2], buf2[MAX_INPUT_LENGTH + 40];
 
   if (apply_soundproof(ch))
     return;
@@ -63,7 +63,7 @@ void do_say(struct char_data *ch, char *argument,
 
 void do_shout(struct char_data *ch, char *argument,
               const char * UNUSED(cmd)) {
-  char buf1[MAX_INPUT_LENGTH + 40], buf2[MAX_INPUT_LENGTH + 40];
+  char buf1[MAX_INPUT_LENGTH * 2], buf2[MAX_INPUT_LENGTH + 40];
   struct descriptor_data *i;
   extern int Silence;
 
@@ -157,7 +157,7 @@ void do_tell(struct char_data *ch, char *argument,
              const char * UNUSED(cmd)) {
   struct char_data *vict;
   char name[100], message[MAX_INPUT_LENGTH + 20],
-    buf[MAX_INPUT_LENGTH + 60], buf2[MAX_INPUT_LENGTH + 60];
+    buf[MAX_INPUT_LENGTH * 2], buf2[MAX_INPUT_LENGTH + 60];
 
   if (apply_soundproof(ch))
     return;
@@ -223,7 +223,7 @@ void do_tell(struct char_data *ch, char *argument,
 void do_whisper(struct char_data *ch, char *argument,
                 const char * UNUSED(cmd)) {
   struct char_data *vict;
-  char name[100], message[MAX_INPUT_LENGTH], buf[MAX_INPUT_LENGTH];
+  char name[100], message[MAX_INPUT_LENGTH], buf[MAX_INPUT_LENGTH * 2];
 
   if (apply_soundproof(ch))
     return;
@@ -258,7 +258,7 @@ void do_whisper(struct char_data *ch, char *argument,
 void do_ask(struct char_data *ch, char *argument,
             const char * UNUSED(cmd)) {
   struct char_data *vict;
-  char name[100], message[MAX_INPUT_LENGTH], buf[MAX_INPUT_LENGTH];
+  char name[100], message[MAX_INPUT_LENGTH], buf[MAX_INPUT_LENGTH * 2];
 
   if (apply_soundproof(ch))
     return;

--- a/src/act.obj1.c
+++ b/src/act.obj1.c
@@ -669,7 +669,7 @@ int newstrlen(char *p) {
 
 void do_give(struct char_data *ch, char *argument,
              const char * UNUSED(cmd)) {
-  char obj_name[200], vict_name[80], buf[132];
+  char obj_name[200], vict_name[80], buf[MAX_BUF_LENGTH * 2];
   char arg[80], newarg[100];
   int amount, num, p, count;
   struct char_data *vict;

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -306,7 +306,7 @@ void do_backstab(struct char_data *ch, char *argument,
 void do_order(struct char_data *ch, char *argument,
               const char * UNUSED(cmd)) {
   char name[100], message[256];
-  char buf[256];
+  char buf[MAX_BUF_LENGTH * 2];
   bool found = FALSE;
   int org_room;
   struct char_data *victim;

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -76,7 +76,7 @@ void do_guard(struct char_data *ch, char *argument,
 
 void do_junk(struct char_data *ch, char *argument,
              const char * UNUSED(cmd)) {
-  char arg[100], buf[100], newarg[100];
+  char arg[100], buf[MAX_BUF_LENGTH], newarg[100];
   struct obj_data *tmp_object;
   int num, p, count, value = 0;
 
@@ -1857,7 +1857,7 @@ void do_gname(struct char_data *ch, char *arg,
 
 void do_donate(struct char_data *ch, char *argument,
                const char * UNUSED(cmd)) {
-  char arg[100], buf[100], newarg[100];
+  char arg[100], buf[MAX_BUF_LENGTH], newarg[100];
   struct obj_data *tmp_object;
   int num, p, count;
 

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -1056,7 +1056,7 @@ void do_stat(struct char_data *ch, char *argument,
   extern char *spells[];
   struct affected_type *aff;
   char arg1[MAX_STRING_LENGTH];
-  char buf[MAX_STRING_LENGTH];
+  char buf[MAX_STRING_LENGTH * 2];
   char buf2[MAX_STRING_LENGTH];
   struct room_data *rm = 0;
   struct char_data *k = 0;
@@ -2059,7 +2059,7 @@ void do_force(struct char_data *ch, char *argument,
 void force_action(struct char_data *ch, char *argument, int npc_ok) {
   struct descriptor_data *i;
   struct char_data *vict;
-  char name[100], to_force[100], buf[100];
+  char name[100], to_force[100], buf[MAX_BUF_LENGTH];
 
   if (IS_NPC(ch) && !npc_ok)
     return;

--- a/src/board.c
+++ b/src/board.c
@@ -437,8 +437,7 @@ int board_display_msg(struct char_data *ch, char *arg, int bnum) {
 
   SPRINTF(buffer, "Message %2d (%s): %-15s -- %s", tmessage, curr_msg->date,
           curr_msg->author, curr_msg->title);
-  SAPPENDF(buffer, "\n\r----------\n\r%s",
-           (curr_msg->text ? curr_msg->text : "(null)"));
+  SAPPENDF(buffer, "\n\r----------\n\r%s", curr_msg->text);
   page_string(ch->desc, buffer, 1);
   return (1);
 

--- a/src/db.c
+++ b/src/db.c
@@ -3259,7 +3259,7 @@ void reboot_text(struct char_data *ch, char *UNUSED(arg),
 
 
 void init_scripts() {
-  char buf[255], buf2[255];
+  char buf[MAX_BUF_LENGTH * 2], buf2[255];
   FILE *f1, *f2;
   int i, count;
   struct char_data *mob;

--- a/src/magic3.c
+++ b/src/magic3.c
@@ -2059,7 +2059,7 @@ void spell_sunray(byte level, struct char_data *ch,
 void spell_know_monster(byte level, struct char_data *ch,
                         struct char_data *victim,
                         struct obj_data *UNUSED(obj)) {
-  char buf[256], buf2[256];
+  char buf[MAX_BUF_LENGTH*2], buf2[256];
   int exp, lev, hits;
 
   extern char *pc_class_types[];

--- a/src/shop.c
+++ b/src/shop.c
@@ -462,7 +462,7 @@ void shopping_value(char *arg, struct char_data *ch,
 
 void shopping_list(char *UNUSED(arg), struct char_data *ch,
                    struct char_data *keeper, int shop_nr) {
-  char buf[MAX_STRING_LENGTH], buf2[100], buf3[100];
+  char buf[MAX_STRING_LENGTH], buf2[MAX_BUF_LENGTH], buf3[100];
   struct obj_data *temp1;
   extern char *drinks[];
   int found_obj;

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -4284,6 +4284,7 @@ int new_thalos_mayor(struct char_data *ch, const char *cmd, char *UNUSED(arg),
       if (time_info.hours == 19) {
         ch->generic = NTMGOALNN;
       }
+      break;
     case NTMGOALNN:            /* north gate */  {
         if (ch->in_room != NTMNGATE) {
           int dir;

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -35,7 +35,7 @@ extern struct weather_data weather_info;
 extern int top_of_world;
 extern struct int_app_type int_app[26];
 
-extern struct title_type titles[4][ABS_MAX_LVL];
+extern struct title_type titles[MAX_CLASS][ABS_MAX_LVL];
 extern char *dirs[];
 
 extern int gSeason;             /* what season is it ? */

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -442,7 +442,7 @@ void invert(char *arg1, char *arg2) {
 
 int jive_box(struct char_data *ch, const char *cmd, char *arg,
              struct obj_data *UNUSED(obj), int type) {
-  char buf[255], buf2[255], buf3[255], tmp[255];
+  char buf[255], buf2[255], buf3[MAX_BUF_LENGTH*4], tmp[255];
 
   if (type != PULSE_COMMAND)
     return (FALSE);
@@ -832,8 +832,8 @@ int magic_user(struct char_data *ch, const char *cmd, char *arg,
         act("$n utters the words 'slllrrrrrrpppp'.", 1, ch, 0, 0, TO_ROOM);
         cast_energy_drain(get_max_level(ch), ch, "", SPELL_TYPE_SPELL, vict,
                           0);
-        break;
       }
+      break;
     default:
       if (ch->attackers <= 2) {
         act("$n utters the words 'frag'.", 1, ch, 0, 0, TO_ROOM);
@@ -2263,6 +2263,7 @@ void say_hello(struct char_data *ch, struct char_data *t) {
       case SKY_CLOUDLESS:
         SPRINTF(buf, "Lovely weather we're having this %s, isn't it, %s.",
                 buf2, GET_NAME(t));
+        break;
       case SKY_CLOUDY:
         SPRINTF(buf, "Nice %s to go for a walk, %s.", buf2, GET_NAME(t));
         break;

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -416,7 +416,7 @@ const byte saving_throws[MAX_CLASS][5][ABS_MAX_LVL] = {
 };
 
 
-void spello(int nr, byte beat, byte pos, byte mlev, byte clev, byte dlev,
+void spello(int nr, ubyte beat, byte pos, byte mlev, byte clev, byte dlev,
             ubyte mana, sh_int tar, void *func, sh_int sf) {
   skill_info[nr].spell_pointer = func;
   skill_info[nr].beats = beat;

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -835,7 +835,7 @@ struct syllable syls[] = {
 
 void say_spell(struct char_data *ch, int si) {
   char buf[MAX_STRING_LENGTH], splwd[MAX_BUF_LENGTH];
-  char buf2[MAX_STRING_LENGTH];
+  char buf2[MAX_STRING_LENGTH * 2];
 
   int j, offs;
   struct char_data *temp_char;

--- a/src/spell_parser.h
+++ b/src/spell_parser.h
@@ -3,7 +3,7 @@
 
 void do_cast(struct char_data *ch, char *argument, const char *cmd);
 
-void spello(int nr, byte beat, byte pos, byte mlev, byte clev, byte dlev,
+void spello(int nr, ubyte beat, byte pos, byte mlev, byte clev, byte dlev,
             ubyte mana, sh_int tar, spell_func *func, sh_int sf);
 
 #endif

--- a/src/spells2.c
+++ b/src/spells2.c
@@ -198,6 +198,7 @@ void cast_mana(byte level, struct char_data *ch, char *UNUSED(arg), int type,
          tar_ch; tar_ch = tar_ch->next_in_room)
       if (tar_ch != ch)
         spell_mana(level, ch, tar_ch, 0);
+    break;
   default:
     log_msg("Serious problem in 'mana'");
     break;
@@ -3220,6 +3221,7 @@ void cast_feeblemind(byte level, struct char_data *ch, char *UNUSED(arg),
   switch (type) {
   case SPELL_TYPE_POTION:
     spell_feeblemind(level, ch, ch, 0);
+    break;
   case SPELL_TYPE_SPELL:
   case SPELL_TYPE_SCROLL:
   case SPELL_TYPE_WAND:
@@ -3510,7 +3512,7 @@ void cast_entangle(byte level, struct char_data *ch, char *UNUSED(arg),
          tar_ch; tar_ch = tar_ch->next_in_room)
       if (!in_group(tar_ch, ch) && !IS_IMMORTAL(tar_ch))
         spell_entangle(level, ch, tar_ch, 0);
-
+    break;
   default:
     log_msg("serious screw-up in entangle.");
     break;
@@ -3533,7 +3535,7 @@ void cast_snare(byte level, struct char_data *ch, char *UNUSED(arg),
          tar_ch; tar_ch = tar_ch->next_in_room)
       if (!in_group(tar_ch, ch) && !IS_IMMORTAL(tar_ch))
         spell_snare(level, ch, tar_ch, 0);
-
+    break;
   default:
     log_msg("serious screw-up in snare.");
     break;
@@ -3573,6 +3575,7 @@ void cast_barkskin(byte level, struct char_data *ch, char *UNUSED(arg),
          tar_ch; tar_ch = tar_ch->next_in_room)
       if (!in_group(tar_ch, ch))
         spell_barkskin(level, ch, tar_ch, 0);
+    break;
   default:
     log_msg("serious screw-up in barkskin.");
     break;
@@ -3702,6 +3705,7 @@ void cast_silence(byte level, struct char_data *ch, char *UNUSED(arg),
   switch (type) {
   case SPELL_TYPE_POTION:
     spell_silence(level, ch, ch, 0);
+    break;
   case SPELL_TYPE_SPELL:
   case SPELL_TYPE_SCROLL:
   case SPELL_TYPE_WAND:
@@ -3714,6 +3718,7 @@ void cast_silence(byte level, struct char_data *ch, char *UNUSED(arg),
          tar_ch; tar_ch = tar_ch->next_in_room)
       if (!in_group(tar_ch, ch) && !IS_IMMORTAL(tar_ch))
         spell_silence(level, ch, tar_ch, 0);
+    break;
   default:
     log_msg("serious screw-up in silence.");
     break;

--- a/src/test.security.c
+++ b/src/test.security.c
@@ -27,7 +27,7 @@ void randomize_buf(void *buf, size_t nbytes) {
 Test(security, parse_cidr_empty_string_v4) {
   char arg[255];
   struct in_addr a, mask;
-  SPRINTF(arg, "");
+  memset(arg, '\0', sizeof(arg));
   cr_assert_not(parse_cidr(AF_INET, arg, &a, &mask));
 }
 
@@ -66,7 +66,7 @@ Test(security, parse_cidr_no_prefix_v4) {
 Test(security, parse_cidr_empty_string_v6) {
   char arg[255];
   struct in6_addr a, mask;
-  SPRINTF(arg, "");
+  memset(arg, '\0', sizeof(arg));
   cr_assert_not(parse_cidr(AF_INET6, arg, &a, &mask));
 }
 

--- a/src/utility.c
+++ b/src/utility.c
@@ -2437,6 +2437,7 @@ void set_racial_stuff(struct char_data *mob) {
   case RACE_HORSE:
     mob->player.weight = 400;
     mob->player.height = 175;
+    break;
   case RACE_ORC:
   case RACE_HALFORC:
     mob->player.weight = 150;


### PR DESCRIPTION
* src/board.c - was checking for a null pointer when it was a value
* src/spec_procs2.c - was hard coding 4 classes when it should be using
MAX_CLASS
* src/spell_parser.c/.h - static array of structs using a value of 250
in a signed byte - changed to ubyte
* Fixed multiple new GCC warnings including string format empty, truncations, case statement fall throughs, etc.