### PR TITLE
Fixes a subtle bug in `file_to_string()`.

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2775,8 +2775,10 @@ int file_to_string(char *name, char *buf) {
       }
 
       strcat(buf, tmp);
-      *(buf + strlen(buf) + 1) = '\0';
-      *(buf + strlen(buf)) = '\r';
+      if (buf[strlen(buf)-1] == '\n') {
+	*(buf + strlen(buf) + 1) = '\0';
+	*(buf + strlen(buf)) = '\r';
+      }
     }
   }
   while (!feof(fl));

--- a/src/test.db.c
+++ b/src/test.db.c
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 #include <criterion/criterion.h>
 #include "config.h"
 #include "db.h"
@@ -60,4 +62,82 @@ Test(fread_string, long_sting_na) {
    /* fread_string saves two bytes at end for \0 and (presumably) a
      potential \r. */
   cr_assert_str_eq(result, "abc");
+}
+
+extern int file_to_string(char *, char *);
+
+char *temp_dir;
+char template[256];
+char *temp_file;
+
+void setup_file_to_string(void) {
+  sprintf(template, "silly-test.XXXXXX");
+  temp_dir = mkdtemp(template);
+  if (temp_dir == NULL) {
+    perror("mkdtemp");
+    return;
+  }
+  temp_file = (char *)malloc(strlen(template) + strlen("/file.txt") + 1);
+  sprintf(temp_file, "%s/file.txt", temp_dir);
+}
+
+void teardown_file_to_string(void) {
+  perror("teardown");
+  if (unlink(temp_file) != 0) {
+    perror("unlink");
+  }
+  free(temp_file);
+  temp_file = NULL;
+  if (rmdir(temp_dir) != 0) {
+    perror("rmdir");
+  }
+  temp_dir = NULL;
+  template[0] = '\0';
+}
+
+Test(file_to_string, reads_contents, .init = setup_file_to_string,
+     .fini = teardown_file_to_string) {
+  char buf[256];
+  FILE *fp;
+  int result;
+
+  fp = fopen(temp_file, "w");
+  fwrite("contents\n", sizeof(char), strlen("contents\n"), fp);
+  fclose(fp);
+  
+  result = file_to_string(temp_file, buf);
+  cr_assert(result == 0);
+  cr_assert(0 == strcmp(buf, "contents\n\r"));
+}
+
+Test(file_to_string, returns_empty_string_if_cannot_open,
+     .init = setup_file_to_string, .fini = teardown_file_to_string) {
+  char buf[256];
+  FILE *fp;
+  int result;
+
+  result = file_to_string(temp_file, buf);
+  cr_assert(result == -1);
+  cr_assert(strlen(buf) == 0);
+}
+
+Test(file_to_string, will_not_read_a_file_thats_too_big,
+     .init = setup_file_to_string, .fini = teardown_file_to_string) {
+  char buf[MAX_STRING_LENGTH];
+  FILE *fp;
+  int result;
+  int i;
+
+  if (!(fp = fopen(temp_file, "w"))) {
+    perror("fopen");
+  }
+  for(i=0; i<MAX_STRING_LENGTH+2; i++) {
+    fwrite(" ", sizeof(char), 1, fp);
+  }
+  fwrite("\n", sizeof(char), 1, fp);
+  fclose(fp);
+
+  result = file_to_string(temp_file, buf);
+  cr_assert(result == -1);
+  cr_assert(strlen(buf) == 0);
 }


### PR DESCRIPTION
This function reads characters up to 100 characters at a time,
and is meant to add a `\r` after each newline; it relies on the
behavior of `fgets()` that only reads up until a newline or EOF.
Under an assumption that all the lines in the file to be read
are less than 100 characters long, this works as expected,
translating `\n` into `\n\r`. However, if a line is _longer_
than 100 characters, this ends up inserting a `\r` into the
middle of the line, since `fgets()` will also stop reading if
it hits the maximum character limit even without finding a
newline.