### PR TITLE
README: add Linux reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ brew install autoconf
 $ brew install automake
 ```
 
-## Windows (WSL)
+## Windows (WSL) and GNU/Linux
 
 Install `criterion` unit testing library:
 ```


### PR DESCRIPTION
The installation instructions for WSL both work on Windows
or GNU/Linux distros, this commit makes it explicit.