### PR TITLE
Fix autoconf detection of Criterion library

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You will then need to add `CFLAGS` and `LDFLAGS` telling `configure`
 where to find the library, as in:
 ```
 ./configure CFLAGS="-I"`pwd`/criterion-v2.3.3/include \
+  CPPFLAGS="-I"`pwd`/criterion-v2.3.3/include \
   LDFLAGS=-L`pwd`/criterion-v2.3.3/lib
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_CHECK_HEADERS([criterion/criterion.h],[],[
   AC_MSG_WARN(unit tests will not be runnable without Criterion library)
   AC_MSG_WARN(See https://github.com/Snaipe/Criterion/)
 ])
-AC_CHECK_LIB(criterion,extmatch,[
+AC_CHECK_LIB(criterion,cr_log,[
   true
 ],[
   AC_MSG_WARN(unit tests will not be runnable without Criterion library)


### PR DESCRIPTION
The existing `AC_CHECK_LIB` test was trying to find a symbol that was not, apparently, exported by the library. Having used the `strings` command to examine the lib revealed a function we can use successfully for the test.

In addition, the `AC_CHECK_HEADERS` was only partially finding the Criterion header files; turns out `-I` including them in *both* `CFLAGS` and `CPPFLAGS` (even though we don't have any C++ in the project) gets the test to pass properly. Updated `README.md` to document this.